### PR TITLE
fix: check equality before setting prop

### DIFF
--- a/editor-components/EditorComponent.tsx
+++ b/editor-components/EditorComponent.tsx
@@ -43,7 +43,7 @@ export interface iComponent {
   getExportedCSSClasses(): { [key: string]: string };
   getCSSClasses(sectionName?: string | null): any;
   addProp(prop: TypeUsableComponentProps): void;
-  setProp(key: string, value: any): void;
+  setProp(key: string, value: any, checkEquality?: boolean): void;
   setCSSClasses(key: string, value: { id: string; class: string }[]): void;
   decorateCSS(cssValue: string): string;
   getCategory(): CATEGORIES;
@@ -135,7 +135,7 @@ export abstract class Component
 
     if (props?.props?.length) {
       props?.props.forEach((prop: TypeUsableComponentProps) => {
-        this.setProp(prop.key, prop.value);
+        this.setProp(prop.key, prop.value, false);
       });
     }
 
@@ -395,12 +395,13 @@ export abstract class Component
     this.state.componentProps.props.push(prop);
   }
 
-  setProp(key: string, value: any): void {
+  setProp(key: string, value: any, checkEquality: boolean = true): void {    
     let i = this.state.componentProps.props
       .map((prop: any) => prop.key)
       .indexOf(key);
 
     if (i == -1) return;
+    if(checkEquality && this.state.componentProps.props[i].value == value) return;
 
     this.state.componentProps.props[i].value = value;
     this.state.componentProps.props[i] = this.attachValueGetter(

--- a/editor-components/EditorComponent.tsx
+++ b/editor-components/EditorComponent.tsx
@@ -43,7 +43,7 @@ export interface iComponent {
   getExportedCSSClasses(): { [key: string]: string };
   getCSSClasses(sectionName?: string | null): any;
   addProp(prop: TypeUsableComponentProps): void;
-  setProp(key: string, value: any, checkEquality?: boolean): void;
+  setProp(key: string, value: any): void;
   setCSSClasses(key: string, value: { id: string; class: string }[]): void;
   decorateCSS(cssValue: string): string;
   getCategory(): CATEGORIES;

--- a/editor-components/EditorComponent.tsx
+++ b/editor-components/EditorComponent.tsx
@@ -135,7 +135,7 @@ export abstract class Component
 
     if (props?.props?.length) {
       props?.props.forEach((prop: TypeUsableComponentProps) => {
-        this.setProp(prop.key, prop.value, false);
+        this.setProp(prop.key, prop.value);
       });
     }
 
@@ -395,13 +395,24 @@ export abstract class Component
     this.state.componentProps.props.push(prop);
   }
 
-  setProp(key: string, value: any, checkEquality: boolean = true): void {    
+  setProp(key: string, value: any): void {
     let i = this.state.componentProps.props
       .map((prop: any) => prop.key)
       .indexOf(key);
 
-    if (i == -1) return;
-    if(checkEquality && this.state.componentProps.props[i].value == value) return;
+    const prop: TypeUsableComponentProps = this.state.componentProps.props[i];
+
+    const isInvalidIndex = i === -1;
+    const isMatchingSimpleValue =
+      prop.type !== "array" && prop.type !== "object" && prop.value === value;
+    const isMatchingComplexValue =
+      (prop.type === "array" || prop.type === "object") &&
+      prop.value.some((item) => item.getPropValue) &&
+      prop.value === value;
+
+    if (isInvalidIndex || isMatchingSimpleValue || isMatchingComplexValue) {
+      return;
+    }
 
     this.state.componentProps.props[i].value = value;
     this.state.componentProps.props[i] = this.attachValueGetter(


### PR DESCRIPTION
This process will prevent unnecessary state upates. For example: when the inline editor renders