### PR TITLE
feat: ConversionTrackingService and InteractionManager extension

### DIFF
--- a/animation-engine/ConversionTrackingService.ts
+++ b/animation-engine/ConversionTrackingService.ts
@@ -1,0 +1,14 @@
+export class ConversionTrackingService {
+  static track(): void {
+    const publicUrl = (import.meta as any).env.VITE_API_URL || "";
+    if (!publicUrl) return;
+    fetch(`${publicUrl}/fn-execute/conversion`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        event_name: "interaction_conversion",
+        timestamp: new Date().toISOString(),
+      }),
+    }).catch(() => {});
+  }
+}

--- a/animation-engine/InteractionManager.ts
+++ b/animation-engine/InteractionManager.ts
@@ -43,6 +43,7 @@ import { ModalActionHandler } from "./ModalActionHandler";
 import { NavigateActionHandler } from "./NavigateActionHandler";
 import { TrackEventActionHandler } from "./TrackEventActionHandler";
 import { detectSelectorSpecificity } from "./selector-utils";
+import { ConversionTrackingService } from "./ConversionTrackingService";
 
 // ── Baseline Style Store ───────────────────────────────────────────────────
 
@@ -506,6 +507,9 @@ export class InteractionManager {
                     undefined,
                     animFields.removeOnComplete
                   );
+                  if (interaction.isConversion) {
+                    ConversionTrackingService.track();
+                  }
                 };
 
                 if (delay <= 0) {
@@ -648,6 +652,9 @@ export class InteractionManager {
         console.warn(
           `[InteractionManager] Unknown action type: ${(interaction.action as any).type}`
         );
+    }
+    if (interaction.isConversion) {
+      ConversionTrackingService.track();
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds ConversionTrackingService to animation-engine for tracking conversion goals
- Extends InteractionManager with interaction event emission wiring
- Supports the interactions feature in landing-composer (frontend-composer#1399)

## Test plan
- Verify ConversionTrackingService initializes and tracks goal events
- Verify InteractionManager fires events that ConversionTrackingService receives
- Run interactions E2E suite in landing-composer-tests

Generated with Claude Code