### PR TITLE
feat(base): :where()-wrap theme palette + schema-tolerant editor reads

### DIFF
--- a/animation-engine/migrateLegacyInteractions.test.ts
+++ b/animation-engine/migrateLegacyInteractions.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { migrateLegacyInteractions, LegacyInteractionType } from "./migrateLegacyInteractions";
+import { AnimateActionConfig, OpenModalActionConfig } from "../../types/interaction";
+
+describe("migrateLegacyInteractions", () => {
+  const COMPONENT_ID = "abc123";
+
+  it("(a) migrates an animate action with full new fields", () => {
+    const legacy: Record<string, LegacyInteractionType[]> = {
+      heading: [
+        {
+          type: "Click",
+          trigger_action: "animate",
+          animation_kind: "bounceIn",
+          duration_ms: 1200,
+          easing: "ease-in-out",
+          visible_on: "Desktop",
+          delay_seconds: 0.5,
+        },
+      ],
+    };
+
+    const result = migrateLegacyInteractions(legacy, COMPONENT_ID);
+
+    expect(result).toHaveLength(1);
+    const interaction = result[0];
+    expect(interaction.action.type).toBe("animate");
+    expect(interaction.trigger.type).toBe("click");
+
+    const action = interaction.action as AnimateActionConfig;
+    expect(action.animation.engine).toBe("animate-css");
+    expect((action.animation as any).animationName).toBe("bounceIn");
+    expect(action.timing.duration).toBe(1200);
+    expect(action.timing.easing).toBe("ease-in-out");
+    // delay_seconds is preserved into timing.delay (ms).
+    expect(action.timing.delay).toBe(500);
+    expect(action.target.type).toBe("selector");
+
+    // Legacy meta block carries the device + display fields forward.
+    const meta = (interaction as any)._legacyMeta;
+    expect(meta).toBeDefined();
+    expect(meta.visibleOn).toBe("Desktop");
+  });
+
+  it("(b) animate action with missing animation_kind falls back to fadeIn", () => {
+    const legacy: Record<string, LegacyInteractionType[]> = {
+      heading: [
+        {
+          type: "Hover",
+          trigger_action: "animate",
+          duration_ms: 800,
+        },
+      ],
+    };
+
+    const result = migrateLegacyInteractions(legacy, COMPONENT_ID);
+
+    expect(result).toHaveLength(1);
+    const action = result[0].action as AnimateActionConfig;
+    expect((action.animation as any).animationName).toBe("fadeIn");
+    // Defaults still applied for the unspecified fields.
+    expect(action.timing.duration).toBe(800);
+    expect(action.timing.easing).toBe("ease-out");
+  });
+
+  it("also migrates the very-old PlayAnimation casing", () => {
+    const legacy: Record<string, LegacyInteractionType[]> = {
+      heading: [
+        {
+          type: "Click",
+          trigger_action: "PlayAnimation",
+          animation_kind: "shake",
+        },
+      ],
+    };
+
+    const result = migrateLegacyInteractions(legacy, COMPONENT_ID);
+
+    expect(result).toHaveLength(1);
+    const action = result[0].action as AnimateActionConfig;
+    expect(action.type).toBe("animate");
+    expect((action.animation as any).animationName).toBe("shake");
+    // Default fallbacks for duration_ms and easing.
+    expect(action.timing.duration).toBe(600);
+    expect(action.timing.easing).toBe("ease-out");
+  });
+
+  it("(c) Show Modal still works (regression)", () => {
+    const legacy: Record<string, LegacyInteractionType[]> = {
+      "cta-button": [
+        {
+          type: "Click",
+          trigger_action: "Show Modal",
+          modal: "SignUpModal",
+          visible_on: "All",
+          show_once: true,
+        },
+      ],
+    };
+
+    const result = migrateLegacyInteractions(legacy, COMPONENT_ID);
+
+    expect(result).toHaveLength(1);
+    const interaction = result[0];
+    const action = interaction.action as OpenModalActionConfig;
+    expect(action.type).toBe("open-modal");
+    expect(action.modalId).toBe("SignUpModal");
+    expect(interaction.trigger.type).toBe("click");
+  });
+
+  it("skips Show Modal entries that are missing the modal id", () => {
+    const legacy: Record<string, LegacyInteractionType[]> = {
+      key: [{ type: "Click", trigger_action: "Show Modal" }],
+    };
+    expect(migrateLegacyInteractions(legacy, COMPONENT_ID)).toHaveLength(0);
+  });
+});

--- a/animation-engine/migrateLegacyInteractions.ts
+++ b/animation-engine/migrateLegacyInteractions.ts
@@ -18,8 +18,13 @@ import {
   Interaction,
   Interactions,
   OpenModalActionConfig,
+  AnimateActionConfig,
   InteractionTrigger,
+  DEFAULT_TIMING,
 } from "../../types/interaction";
+import { Logger } from "classes/Logger";
+
+const log = new Logger("migrateLegacyInteractions");
 
 // ---------------------------------------------------------------------------
 // Legacy types (from EditorComponent.tsx)
@@ -28,11 +33,15 @@ import {
 export interface LegacyInteractionType {
   type?: string; // "Click" | "Hover" | "Form Submission"
   modal?: string;
-  trigger_action?: string; // "Show Modal"
+  trigger_action?: string; // "Show Modal" | "animate" | "PlayAnimation"
   visible_on?: string; // "All" | "Desktop" | "Mobile" | "Tablet"
   show_once?: boolean;
   display_option?: "show_once" | "show_always" | "show_with_delay";
   delay_seconds?: number;
+  // D3-router animate fields (added when trigger_action === "animate")
+  animation_kind?: string;     // Animate.css name (one of 89), e.g. "fadeIn"
+  duration_ms?: number;        // Animation duration in milliseconds
+  easing?: string;             // CSS easing string, e.g. "ease-out"
 }
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
@@ -102,11 +111,56 @@ export function migrateLegacyInteractions(
     const selector = keyToSelector(key, componentId);
 
     for (const legacy of interactionList) {
-      // Only handle "Show Modal" trigger action
-      if (legacy.trigger_action !== "Show Modal") continue;
-      if (!legacy.modal) continue;
-
+      const triggerAction = legacy.trigger_action;
       const trigger = legacyTypeToTrigger(legacy.type);
+
+      // ── Animate action (D3 router output) ─────────────────────────
+      // The router now emits `trigger_action: "animate"` with new fields
+      // (animation_kind/duration_ms/easing). The very-old casing
+      // "PlayAnimation" is also accepted for backward compatibility.
+      if (triggerAction === "animate" || triggerAction === "PlayAnimation") {
+        let animationName = legacy.animation_kind;
+        if (!animationName) {
+          log.warn("missing_animation_kind_falling_back_to_fadeIn", { trigger_action: triggerAction, type: legacy.type });
+          animationName = "fadeIn";
+        }
+        const action: AnimateActionConfig = {
+          type: "animate",
+          animation: { engine: "animate-css", animationName },
+          timing: {
+            ...DEFAULT_TIMING,
+            duration: typeof legacy.duration_ms === "number" ? legacy.duration_ms : 600,
+            easing: legacy.easing ?? "ease-out",
+            delay: typeof legacy.delay_seconds === "number" ? legacy.delay_seconds * 1000 : DEFAULT_TIMING.delay,
+          },
+          target: { type: "selector", selector },
+        };
+
+        const interaction: Interaction = {
+          id: uuidv4(),
+          name: `Legacy: ${legacy.type || "Click"} → animate ${animationName}`,
+          trigger,
+          action,
+          enabled: true,
+          priority: trigger.type === "click" ? 20 : 15,
+        };
+
+        // Preserve the same legacy metadata block as the modal path so
+        // runtime code that reads visible_on / display_option keeps working.
+        (interaction as any)._legacyMeta = {
+          selector,
+          visibleOn: legacy.visible_on || "All",
+          displayOption: legacy.display_option || (legacy.show_once ? "show_once" : "show_always"),
+          delaySeconds: legacy.delay_seconds,
+        };
+
+        result.push(interaction);
+        continue;
+      }
+
+      // ── Open-modal action (existing path) ─────────────────────────
+      if (triggerAction !== "Show Modal") continue;
+      if (!legacy.modal) continue;
 
       const action: OpenModalActionConfig = {
         type: "open-modal",

--- a/composer-base-components/base/base.module.scss
+++ b/composer-base-components/base/base.module.scss
@@ -1,7 +1,8 @@
 @use "./utitilities/viewports.module.scss" as *;
 @import "./effects.scss";
 
-.h1{
+// Wrapped in :where() so AI-managed (.auto-generate-*) and design-tab class rules trivially win the cascade. Spec: design > theme.
+:where(.h1){
      font-size: calc(3.5 * var(--composer-font-size-md));
      line-height: 1.2em;
      letter-spacing: -0.02em;
@@ -22,7 +23,8 @@
      }
 }
 
-.h2{
+// Wrapped in :where() so AI-managed (.auto-generate-*) and design-tab class rules trivially win the cascade. Spec: design > theme.
+:where(.h2){
     font-size: calc(2.75 * var(--composer-font-size-md));
     line-height: 1.25em;
     letter-spacing: -0.01em;
@@ -43,7 +45,8 @@
     }
 }
 
-.h3{
+// Wrapped in :where() so AI-managed (.auto-generate-*) and design-tab class rules trivially win the cascade. Spec: design > theme.
+:where(.h3){
     font-size: calc(2 * var(--composer-font-size-md));
     line-height: 1.3em;
     letter-spacing: -0.01em;
@@ -63,7 +66,8 @@
     }
 }
 
-.h4{
+// Wrapped in :where() so AI-managed (.auto-generate-*) and design-tab class rules trivially win the cascade. Spec: design > theme.
+:where(.h4){
     font-size: calc(1.75 * var(--composer-font-size-md));
     line-height: 1.35em;
     letter-spacing: 0em;
@@ -83,7 +87,8 @@
     }
 }
 
-.h5{
+// Wrapped in :where() so AI-managed (.auto-generate-*) and design-tab class rules trivially win the cascade. Spec: design > theme.
+:where(.h5){
     font-size: calc(1.5 * var(--composer-font-size-md));
     line-height: 1.4em;
     letter-spacing: 0em;
@@ -103,7 +108,8 @@
     }
 }
 
-.h6{
+// Wrapped in :where() so AI-managed (.auto-generate-*) and design-tab class rules trivially win the cascade. Spec: design > theme.
+:where(.h6){
     font-size: calc(1.25 * var(--composer-font-size-md));
     line-height: 1.45em;
     letter-spacing: 0em;
@@ -123,7 +129,8 @@
     }
 }
 
-.p{
+// Wrapped in :where() so AI-managed (.auto-generate-*) and design-tab class rules trivially win the cascade. Spec: design > theme.
+:where(.p){
     line-height: 1.6em;
     font-size: calc(1 * var(--composer-font-size-md));
     margin-top: 0;
@@ -142,11 +149,14 @@
 }
 
 
+// Wrapped background-color (theme palette plumbing) in :where() so AI-managed (.auto-generate-*) and design-tab class rules trivially win the cascade. Spec: design > theme.
+:where(.container) {
+    background-color: var(--composer-html-background);
+}
 .container{
     position: relative;
     width: 100%;
     padding: 120px 60px;
-    background-color: var(--composer-html-background);
     container-type: inline-size;
 
     &.full {
@@ -298,7 +308,6 @@
     .sectionDescription{
         font-size: calc(1.125 * var(--composer-font-size-md));
         line-height: 1.6em;
-        color: var(--composer-tertiary-color);
         margin-bottom: 1.5em;
 
         @container (max-width: #{$composer-tablet-width}) {
@@ -309,36 +318,45 @@
             font-size: calc(1 * var(--composer-font-size-md)) !important;
         }
     }
-    
 
-    &.colorful{
-        .sectionTitle{
-            color: var(--composer-primary-color);
-        }
-        .sectionSubTitle{
-            color: var(--composer-primary-color);
-            &.badge{
-                background: color-mix(in srgb, var(--composer-primary-color), var(--composer-html-background) 80%);
-            }
-        }
-        .sectionDescription{
-            color: var(--composer-tertiary-color);
+
+}
+
+// Wrapped in :where() so AI-managed (.auto-generate-*) and design-tab class rules trivially win the cascade. Spec: design > theme.
+:where(.sectionDescription) {
+    color: var(--composer-tertiary-color);
+}
+
+// Wrapped in :where() so AI-managed (.auto-generate-*) and design-tab class rules trivially win the cascade. Spec: design > theme.
+:where(.container.colorful) {
+    :where(.sectionTitle){
+        color: var(--composer-primary-color);
+    }
+    :where(.sectionSubTitle){
+        color: var(--composer-primary-color);
+        &:where(.badge){
+            background: color-mix(in srgb, var(--composer-primary-color), var(--composer-html-background) 80%);
         }
     }
-    &.monochrome{
-        .sectionTitle{
+    :where(.sectionDescription){
+        color: var(--composer-tertiary-color);
+    }
+}
+
+// Wrapped in :where() so AI-managed (.auto-generate-*) and design-tab class rules trivially win the cascade. Spec: design > theme.
+:where(.container.monochrome) {
+    :where(.sectionTitle){
+        color: var(--composer-font-color-primary);
+    }
+    :where(.sectionSubTitle){
+        color: var(--composer-font-color-primary);
+        &:where(.badge){
             color: var(--composer-font-color-primary);
+            background: color-mix(in srgb, var(--composer-html-background), var(--composer-font-color-primary) 10%);
         }
-        .sectionSubTitle{
-            color: var(--composer-font-color-primary);
-            &.badge{
-                color: var(--composer-font-color-primary);
-                background: color-mix(in srgb, var(--composer-html-background), var(--composer-font-color-primary) 10%);
-            }
-        }
-        .sectionDescription{
-            color: var(--composer-tertiary-color);
-        }
+    }
+    :where(.sectionDescription){
+        color: var(--composer-tertiary-color);
     }
 }
 

--- a/editor-components/EditorComponent.tsx
+++ b/editor-components/EditorComponent.tsx
@@ -409,25 +409,76 @@ export abstract class Component
   static category: CATEGORIES;
   private static _dbgStyle = 'padding:2px 4px;border-radius:2px;font-weight:bold;color:white;background:#4CAF50;';
 
+  // Hash of last-emitted structural state, used to skip emitting
+  // COMPONENT_DID_UPDATE on internal state changes (e.g. slider autoplay
+  // tick) that don't actually mutate any structural surface external
+  // subscribers care about. Subscribers in editor.tsx / preview.tsx
+  // re-scan the DOM and call setElementsTree on every emit; without
+  // this guard a slider tick cascades into a full Playground re-render.
+  private _lastStructuralEmitHash: string | null = null;
+
+  /**
+   * Computes a stable structural hash of the inputs that external
+   * subscribers actually care about: typed props, cssClasses,
+   * interactions, type, id. Internal state (this.state.states — slider
+   * activeSlide, hover flags, animation kicks, etc.) is intentionally
+   * excluded so it never triggers a structural emit.
+   *
+   * Hashing strategy: stringify each surface independently, join with a
+   * delimiter. Stringification preserves prop array order (important —
+   * reorders are structural). Hashing 50 sections × ~100 props each is
+   * trivial CPU compared to the React render avalanche it prevents.
+   */
+  private _computeStructuralHash(): string {
+    const componentProps = (this.state as any)?.componentProps || {};
+    const props = componentProps.props || [];
+    const cssClasses = componentProps.cssClasses || {};
+    const interactions = componentProps.interactions || {};
+    const type = (this.constructor as typeof Component).name;
+    try {
+      // Strip the dynamic getPropValue function before stringifying — it's a
+      // closure attached on every attachValueGetter pass and would not
+      // serialize stably (functions become undefined / different identity
+      // each render).
+      const propsForHash = props.map((p: any) => {
+        if (p && typeof p === "object") {
+          const { getPropValue, ...rest } = p;
+          return rest;
+        }
+        return p;
+      });
+      return JSON.stringify({
+        p: propsForHash,
+        c: cssClasses,
+        i: interactions,
+        t: type,
+        id: this.id,
+        gid: this.globalComponentId,
+      });
+    } catch {
+      // Fall back to a non-deterministic value so we always emit on
+      // serialization failure — preserves prior behavior for edge cases.
+      return `__unhashable_${Date.now()}`;
+    }
+  }
+
   componentDidUpdate(
     prevProps: Readonly<{}>,
     prevState: Readonly<{ states: any; componentProps: any; }>,
     snapshot?: any
   ): void {
-    const prevPropsArr: any[] = (prevProps as any)?.props || [];
-    const nextPropsArr: any[] = (this.props as any)?.props || [];
-    const propDiffs: { key: string; prev: any; next: any }[] = [];
-    nextPropsArr.forEach((np: any) => {
-      const pp = prevPropsArr.find((p: any) => p?.key === np?.key);
-      if (pp && pp.value !== np.value && (np.type === "string" || np.type === "boolean")) {
-        propDiffs.push({
-          key: np.key,
-          prev: typeof pp.value === "string" ? String(pp.value).slice(0, 80) : pp.value,
-          next: typeof np.value === "string" ? String(np.value).slice(0, 80) : np.value,
-        });
-      }
-    });
-    EventEmitter.emit(EVENTS.COMPONENT_DID_UPDATE, { data: this });
+    // Structural-change guard: external subscribers only need to react when
+    // a structural surface (props array, cssClasses, interactions, type,
+    // id) actually changed. Internal state changes (slider autoplay tick,
+    // hover flag, animation tick) must NOT trigger the emit because each
+    // emit synchronously runs assignIdPageElements + applyStyleCSS and
+    // schedules a setElementsTree (which causes a context update and a
+    // full Playground re-render).
+    const nextHash = this._computeStructuralHash();
+    if (nextHash !== this._lastStructuralEmitHash) {
+      this._lastStructuralEmitHash = nextHash;
+      EventEmitter.emit(EVENTS.COMPONENT_DID_UPDATE, { data: this });
+    }
     this.onComponentDidUpdate?.(prevProps, prevState, snapshot);
   }
 

--- a/editor-components/feature/feature45/feature45.tsx
+++ b/editor-components/feature/feature45/feature45.tsx
@@ -209,9 +209,16 @@ class Feature45 extends BaseFeature {
       sectionSubtitle || sectionTitle || sectionDescription;
 
     const cards = this.castToObject<Card[]>("cards");
-    const itemCountPerRow = this.getPropValue("itemCount");
+    // Schema variants exist in the wild — newer COMPONENTS bucket entries use
+    // `itemsPerRow` / `buttons` while the original component used
+    // `itemCount` / `sectionButtons`. Read both, pick the populated one.
+    const itemCountPerRow =
+      this.getPropValue("itemCount") || this.getPropValue("itemsPerRow");
 
-    const sectionButtons = this.castToObject<PrimaryButton[]>("sectionButtons");
+    const sectionButtonsRaw =
+      this.castToObject<PrimaryButton[]>("sectionButtons") ||
+      this.castToObject<PrimaryButton[]>("buttons");
+    const sectionButtons = Array.isArray(sectionButtonsRaw) ? sectionButtonsRaw : [];
     const sectionButtonsExist = sectionButtons.some(
       (sectionButton) => !!this.castToString(sectionButton.text),
     );
@@ -254,63 +261,81 @@ class Feature45 extends BaseFeature {
               }}
               className={this.decorateCSS("cards-list")}
             >
-              {cards?.map((card, index) => (
-                <Base.VerticalContent
-                  key={index}
-                  className={this.decorateCSS("card")}
-                >
-                  {this.castToString(card.subtitle) && (
-                    <Base.H6 className={this.decorateCSS("card-subtitle")}>
-                      {card.subtitle}
-                    </Base.H6>
-                  )}
-                  {this.castToString(card.title) && (
-                    <Base.H3 className={this.decorateCSS("card-title")}>
-                      {card.title}
-                    </Base.H3>
-                  )}
-                  {this.castToString(card.description) && (
-                    <Base.P className={this.decorateCSS("card-description")}>
-                      {card.description}
-                    </Base.P>
-                  )}
-                  <div className={this.decorateCSS("card-buttons-wrapper")}>
-                    {card.buttons.map((button, index) => {
-                      const buttonText = this.castToString(button.text);
-                      const buttonExist = buttonText || button.icon;
-                      return (
-                        buttonExist && (
-                          <ComposerLink path={button.url}>
-                            <Base.Button
-                              className={this.decorateCSS("card-button")}
-                              key={index}
-                              buttonType={button.type}
-                            >
-                              {button.icon && (
-                                <Base.Media
-                                  value={button.icon}
-                                  className={this.decorateCSS(
-                                    "card-button-icon",
-                                  )}
-                                />
-                              )}
-                              {buttonText && (
-                                <Base.P
-                                  className={this.decorateCSS(
-                                    "card-button-text",
-                                  )}
-                                >
-                                  {button.text}
-                                </Base.P>
-                              )}
-                            </Base.Button>
-                          </ComposerLink>
-                        )
-                      );
-                    })}
-                  </div>
-                </Base.VerticalContent>
-              ))}
+              {cards?.map((card: any, index: number) => {
+                // Title field uses `title` in the original schema, but newer
+                // bucket entries use `content` (HTML allowed) — fall back.
+                const cardTitle = card.title || card.content;
+                // Each card can carry a singular `button` (object) OR a
+                // `buttons` array. Normalize to an array for rendering.
+                const cardButtons: PrimaryButton[] = Array.isArray(card.buttons)
+                  ? card.buttons
+                  : card.button
+                  ? [card.button]
+                  : [];
+                return (
+                  <Base.VerticalContent
+                    key={index}
+                    className={this.decorateCSS("card")}
+                  >
+                    {card.icon && (
+                      <Base.Media
+                        value={card.icon}
+                        className={this.decorateCSS("card-icon")}
+                      />
+                    )}
+                    {this.castToString(card.subtitle) && (
+                      <Base.H6 className={this.decorateCSS("card-subtitle")}>
+                        {card.subtitle}
+                      </Base.H6>
+                    )}
+                    {this.castToString(cardTitle) && (
+                      <Base.H3 className={this.decorateCSS("card-title")}>
+                        {cardTitle}
+                      </Base.H3>
+                    )}
+                    {this.castToString(card.description) && (
+                      <Base.P className={this.decorateCSS("card-description")}>
+                        {card.description}
+                      </Base.P>
+                    )}
+                    <div className={this.decorateCSS("card-buttons-wrapper")}>
+                      {cardButtons.map((button, index) => {
+                        const buttonText = this.castToString(button.text);
+                        const buttonExist = buttonText || button.icon;
+                        return (
+                          buttonExist && (
+                            <ComposerLink path={button.url}>
+                              <Base.Button
+                                className={this.decorateCSS("card-button")}
+                                key={index}
+                                buttonType={button.type}
+                              >
+                                {button.icon && (
+                                  <Base.Media
+                                    value={button.icon}
+                                    className={this.decorateCSS(
+                                      "card-button-icon",
+                                    )}
+                                  />
+                                )}
+                                {buttonText && (
+                                  <Base.P
+                                    className={this.decorateCSS(
+                                      "card-button-text",
+                                    )}
+                                  >
+                                    {button.text}
+                                  </Base.P>
+                                )}
+                              </Base.Button>
+                            </ComposerLink>
+                          )
+                        );
+                      })}
+                    </div>
+                  </Base.VerticalContent>
+                );
+              })}
             </Base.ListGrid>
           )}
 


### PR DESCRIPTION
## Summary
- `composer-base-components/base/base.module.scss`: lifted `.h1`–`.h6`, `.p`, `.sectionDescription`, `.container.colorful`, `.container.monochrome` theme palette blocks under `:where()` so their specificity collapses to 0,0,0. AI-managed `.auto-generate-*` rules (specificity 0,1,0) now beat them without `!important`. Required so the new element picker's CSS edits land visibly even when a monochrome theme is active.
- `editor-components/EditorComponent.tsx`: schema-tolerant prop reads (button vs buttons, itemCount vs itemsPerRow); structural-hash COMPONENT_DID_UPDATE emission so the slider/animation tick stops re-rendering the whole tree.
- `editor-components/feature/feature45/feature45.tsx`: tolerant of both prop shapes (card.button OR card.buttons, sectionButtons OR buttons, itemCount OR itemsPerRow).
- `animation-engine/migrateLegacyInteractions.ts` + new `.test.ts`: legacy interaction shape migration with unit coverage.

## Companion PRs
- frontend-composer (landing-composer): `feature/ai-element-picker`
- blinkpage-ai-service: `feature/ai-picker-prompts-and-identity-fallback`
- landing-composer-tests: `test/ai-element-picker`

## Test plan
- [ ] `yarn build` passes from landing-composer (consumes this submodule).
- [ ] Pick a description text in the editor → ask AI to make it red → red renders (theme rule loses to AI rule due to :where wrap).
- [ ] Pick a heading in monochrome theme + apply a brand color via `dt_set_theme_color` → brand color renders.
- [ ] Slider tick no longer re-renders the whole canvas tree (only the affected component).
- [ ] feature45 with `card.button` (singular) renders identically to one with `card.buttons` array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
