### PR TITLE
fix(editor): support plain-React-style custom components

### DIFF
--- a/editor-components/EditorComponent.tsx
+++ b/editor-components/EditorComponent.tsx
@@ -417,6 +417,41 @@ export abstract class Component
   // this guard a slider tick cascades into a full Playground re-render.
   private _lastStructuralEmitHash: string | null = null;
 
+  // --- Protective `state` accessor ----------------------------------------
+  // The framework keeps its editable props in `this.state.componentProps` and
+  // its runtime state in `this.state.states`. A component authored as a plain
+  // React class (the idiomatic pattern) may do `this.state = { ... }` in its
+  // constructor or call `this.setState({ ... })` directly. A raw object
+  // assignment to `this.state` would REPLACE the object and wipe
+  // `componentProps`/`states`, which makes the loader reject the component
+  // ("has no editable props") and crashes `getPropValue`.
+  //
+  // Replacing `state` with a getter/setter lets us preserve the framework keys
+  // across any whole-object assignment (author constructor, React's internal
+  // `instance.state = nextState` during updates) while still letting author
+  // keys live alongside on the same object — so `this.state.x` / `setState`
+  // behave like a normal React component.
+  private _internalState: any = undefined;
+
+  // @ts-ignore — intentionally overrides React's `state` data property with an accessor.
+  get state(): any {
+    return this._internalState;
+  }
+  // @ts-ignore
+  set state(next: any) {
+    const prev = this._internalState;
+    if (prev && prev.componentProps) {
+      this._internalState = {
+        ...prev,
+        ...next,
+        componentProps: next && next.componentProps ? next.componentProps : prev.componentProps,
+        states: next && next.states ? next.states : prev.states,
+      };
+    } else {
+      this._internalState = next;
+    }
+  }
+
   /**
    * Computes a stable structural hash of the inputs that external
    * subscribers actually care about: typed props, cssClasses,
@@ -462,11 +497,12 @@ export abstract class Component
     }
   }
 
-  componentDidUpdate(
-    prevProps: Readonly<{}>,
-    prevState: Readonly<{ states: any; componentProps: any; }>,
-    snapshot?: any
-  ): void {
+  // Framework structural emit, factored out of componentDidUpdate so it can
+  // be chained AHEAD of an author-supplied componentDidUpdate (see
+  // _installFrameworkLifecycle). A plain-React component that defines its own
+  // componentDidUpdate would otherwise shadow the base method and silently
+  // disable editor live-sync.
+  private _emitStructuralUpdate(): void {
     // Structural-change guard: external subscribers only need to react when
     // a structural surface (props array, cssClasses, interactions, type,
     // id) actually changed. Internal state changes (slider autoplay tick,
@@ -479,6 +515,16 @@ export abstract class Component
       this._lastStructuralEmitHash = nextHash;
       EventEmitter.emit(EVENTS.COMPONENT_DID_UPDATE, { data: this });
     }
+  }
+
+  componentDidUpdate(
+    prevProps: Readonly<{}>,
+    prevState: Readonly<{ states: any; componentProps: any; }>,
+    snapshot?: any
+  ): void {
+    // NOTE: the structural emit is NOT called here directly. It runs via the
+    // wrapper installed in the constructor (_installFrameworkLifecycle), which
+    // guarantees it fires even when a subclass overrides componentDidUpdate.
     this.onComponentDidUpdate?.(prevProps, prevState, snapshot);
   }
 
@@ -557,11 +603,49 @@ export abstract class Component
       },
     };
 
+    this._installFrameworkLifecycle();
 
     EventEmitter.emit(EVENTS.COMPONENT_ADDED, { data: this });
   }
 
+  // Chains the framework's own lifecycle work (structural emit, prop
+  // reconciliation) AHEAD of whatever componentDidUpdate / componentWillMount
+  // the subclass resolves to. This mirrors the render() wrapping above and
+  // lets a component author override these lifecycle methods like a normal
+  // React class WITHOUT silently disabling editor live-sync or prop sync.
+  //
+  // `this.componentDidUpdate` here resolves through the prototype chain to the
+  // subclass override if one exists, otherwise to the base passthrough (which
+  // calls the onComponent* hook). Either way the framework work runs first and
+  // the resolved method runs after.
+  private _installFrameworkLifecycle(): void {
+    const resolvedDidUpdate = (this.componentDidUpdate as any)?.bind(this);
+    this.componentDidUpdate = (
+      prevProps: Readonly<{}>,
+      prevState: Readonly<{ states: any; componentProps: any }>,
+      snapshot?: any
+    ): void => {
+      this._emitStructuralUpdate();
+      resolvedDidUpdate?.(prevProps, prevState, snapshot);
+    };
+
+    const resolvedWillMount = (this.componentWillMount as any)?.bind(this);
+    this.componentWillMount = (): void => {
+      this._syncShadowProps();
+      resolvedWillMount?.();
+    };
+  }
+
   componentWillMount() {
+    // NOTE: prop reconciliation is NOT done here directly. It runs via the
+    // wrapper installed in the constructor (_installFrameworkLifecycle), which
+    // guarantees it fires even when a subclass overrides componentWillMount.
+    // Override point for authors who use the framework hook style.
+  }
+
+  // Framework prop reconciliation against shadow (default) props. Factored out
+  // of componentWillMount so it can be chained ahead of an author override.
+  private _syncShadowProps() {
     this.getProps().forEach(({ key, value }) => {
       const propIndex = this.state.componentProps.props.findIndex((prop: any) => prop.key === key);
       if (propIndex === -1) return;


### PR DESCRIPTION
## Problem

Custom components authored as **idiomatic React class components** broke in the page builder. The base `Component` keeps every editable prop in `this.state.componentProps`, so:

- A constructor `this.state = { ... }` **replaced** the state object and wiped `componentProps` → the loader rejected the component (`"<name>" has no editable props`) and `getPropValue` threw.
- Overriding `componentDidUpdate` / `componentWillMount` directly **shadowed** the framework's structural-emit (editor live-sync) and shadow-prop reconciliation.

Net effect: a component using `constructor` state + `setState` + `componentDidMount`/`setInterval` (perfectly valid React) would not register, render, or animate.

## Change (`editor-components/EditorComponent.tsx`)

1. **Protective `state` accessor** — replaces React's plain `state` slot with a getter/setter that preserves the framework-owned keys (`componentProps`, `states`) across any whole-object assignment (author constructor, and React's own internal `instance.state = nextState`), while letting author keys (`np`, `resolved`, …) live alongside on the same object. `this.setState` / `this.state.x` then behave like normal React.

2. **Lifecycle auto-chaining** — the framework's structural emit and prop reconciliation are factored into private methods and chained **ahead** of whatever `componentDidUpdate` / `componentWillMount` the subclass resolves to (installed in the constructor, mirroring the existing `render()` wrapping). Authors can override these lifecycle methods like normal React without disabling editor sync.

No behavior change for existing components: they keep using `setComponentState` / `onComponent*` hooks, which still route through the same state and lifecycle.

## What still differs from plain React (by design)

- `render()` must return a single element (no array/Fragment).
- Content comes from editable props (`addProp` / `getPropValue`), not `this.props`.
- Re-renders are still driven by `setState` — direct `this.state.x = …` mutation does not repaint (same as React).

## Verification

Built an **unmodified** plain-React A/B component (`constructor this.state = {...}`, raw `this.setState`, `componentDidMount` + `setInterval`), uploaded it to a dev project, and confirmed in the editor that it registers, renders, and runs its count-up + 5.2s-loop animation. `accessorLive` confirmed on the base class; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
