### PR TITLE
feat(custom-components): expose load failures for UI surfacing

### DIFF
--- a/custom-component-loader.ts
+++ b/custom-component-loader.ts
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import ComponentsRegistery from "./editor-components/ComponentRegistery";
+import ComponentsRegistery, { CustomComponentLoadFailure } from "./editor-components/ComponentRegistery";
 import { CATEGORIES, Component } from "./editor-components/EditorComponent";
 import * as _EditorComponents from "./editor-components/EditorComponent";
 import * as _BaseModule from "./composer-base-components/base/base";
@@ -143,8 +143,13 @@ function injectStylesheet(css: string, key: string): void {
 export async function loadCustomComponentsFromMeta(
   components: CustomComponentMeta[],
   registry: ComponentsRegistery
-): Promise<void> {
-  if (!components || components.length === 0) return;
+): Promise<CustomComponentLoadFailure[]> {
+  // Shared by reference with the registry so pushes below are reflected;
+  // reset up-front so a clean reload never shows stale failures.
+  const failures: CustomComponentLoadFailure[] = [];
+  registry.setCustomLoadFailures(failures);
+
+  if (!components || components.length === 0) return failures;
 
   const activeComponents = components.filter((c) => c.status === "active" && c.bundle_content);
 
@@ -153,7 +158,7 @@ export async function loadCustomComponentsFromMeta(
       `[CustomComponents] ${components.length} component(s) from API but none have active status with bundle_content.`,
       components.map((c) => ({ name: c.name, status: c.status, hasContent: !!c.bundle_content, content: c.bundle_content }))
     );
-    return;
+    return failures;
   }
 
   const componentsToRegister: (typeof Component)[] = [];
@@ -190,6 +195,12 @@ export async function loadCustomComponentsFromMeta(
             `[CustomComponents] "${comp.name}" (key: "${windowKey}") not found on window.__CUSTOM_COMPONENTS__. Available keys:`,
             loadedKeys
           );
+          failures.push({
+            name: comp.name,
+            version: comp.version,
+            customComponentId: comp._id,
+            reason: "Bundle did not register a component. Re-upload it from the latest CLI / Component Studio build.",
+          });
           continue;
         }
       }
@@ -207,6 +218,12 @@ export async function loadCustomComponentsFromMeta(
       componentsToRegister.push(VersionedClass as unknown as typeof Component);
     } catch (err) {
       console.error(`[CustomComponents] Failed to load "${comp.name}" v${comp.version}:`, err);
+      failures.push({
+        name: comp.name,
+        version: comp.version,
+        customComponentId: comp._id,
+        reason: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 
@@ -217,6 +234,9 @@ export async function loadCustomComponentsFromMeta(
       `[CustomComponents] No components registered. ${activeComponents.length} active component(s) loaded but none matched.`
     );
   }
+
+  registry.setCustomLoadFailures(failures);
+  return failures;
 }
 
 export function getCustomComponentsFromPage(pageJson: string): string[] {

--- a/editor-components/ComponentRegistery.tsx
+++ b/editor-components/ComponentRegistery.tsx
@@ -1,8 +1,23 @@
 import { CATEGORIES, Component, iComponent } from "./EditorComponent";
 
 export type TRegistryState = { [key in CATEGORIES]: typeof Component[] };
+
+/**
+ * A custom component that was fetched but could NOT be registered (bad bundle,
+ * missing addProp, did not extend Component, etc.). Kept OUT of
+ * availableComponents so the page builder never tries to render it; surfaced
+ * separately so the UI can show the user why their component is missing.
+ */
+export type CustomComponentLoadFailure = {
+  name: string;
+  version?: number;
+  reason: string;
+  customComponentId?: string;
+};
+
 class ComponentsRegistery {
   private availableComponents: TRegistryState = {} as TRegistryState;
+  private customLoadFailures: CustomComponentLoadFailure[] = [];
 
   constructor() {
     Object.values(CATEGORIES).forEach((item) => {
@@ -12,6 +27,14 @@ class ComponentsRegistery {
 
   getComponents(): TRegistryState {
     return this.availableComponents;
+  }
+
+  setCustomLoadFailures(failures: CustomComponentLoadFailure[]) {
+    this.customLoadFailures = failures;
+  }
+
+  getCustomLoadFailures(): CustomComponentLoadFailure[] {
+    return this.customLoadFailures;
   }
   register(components: typeof Component[]) {
     components.forEach((component: typeof Component) => {
@@ -78,6 +101,8 @@ class ComponentsRegistery {
       if (typeof window !== "undefined" && window.__CUSTOM_COMPONENTS__) {
         window.__CUSTOM_COMPONENTS__ = {};
       }
+      // Drop recorded load failures too — they are re-derived on next load.
+      this.customLoadFailures = [];
     }
 
     this.availableComponents[category] = [];


### PR DESCRIPTION
## Problem

When a custom component fails to load (bad bundle, missing `addProp`, doesn't extend `Component`, or the bundle didn't register a class), the loader only `console.error`'d it and silently dropped it. The component just never appears in the picker — the user has no idea why.

## Change

- **`ComponentRegistery`**: new `customLoadFailures` channel (`getCustomLoadFailures()` / `setCustomLoadFailures()`), plus a `CustomComponentLoadFailure` type (`name`, `version`, `reason`, `customComponentId`). Kept **separate** from `availableComponents` on purpose, so a failed component never reaches the page builder's `findComponentSignature` / render path. Cleared when the CUSTOM category is cleared.
- **`custom-component-loader`**: `loadCustomComponentsFromMeta` now collects every failure (validation throw, bundle-not-registered, any caught load error), records `{name, version, customComponentId, reason}`, stores them on the registry, and returns them. Healthy-component behavior is unchanged.

## Consumer

The host UI (landing-composer) reads `registry.getCustomLoadFailures()` and renders greyed-out, non-clickable "load failed" entries in the CUSTOM picker with the reason on hover. (Separate PR in landing-composer.)

## Notes

- Independent of the plain-React-state PR (#1239) — different files, merges in any order.
- Verified live: deliberately-broken component shows as a "LOAD FAILED" badge in the picker with the exact reason as a tooltip; valid components render normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
