### PR TITLE
fix(custom-components): isolate uploaded CSS from editor tool tokens

### DIFF
--- a/custom-component-loader.ts
+++ b/custom-component-loader.ts
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import ComponentsRegistery from "./editor-components/ComponentRegistery";
+import ComponentsRegistery, { CustomComponentLoadFailure } from "./editor-components/ComponentRegistery";
 import { CATEGORIES, Component } from "./editor-components/EditorComponent";
 import * as _EditorComponents from "./editor-components/EditorComponent";
 import * as _BaseModule from "./composer-base-components/base/base";
@@ -143,8 +143,13 @@ function injectStylesheet(css: string, key: string): void {
 export async function loadCustomComponentsFromMeta(
   components: CustomComponentMeta[],
   registry: ComponentsRegistery
-): Promise<void> {
-  if (!components || components.length === 0) return;
+): Promise<CustomComponentLoadFailure[]> {
+  // Shared by reference with the registry so pushes below are reflected;
+  // reset up-front so a clean reload never shows stale failures.
+  const failures: CustomComponentLoadFailure[] = [];
+  registry.setCustomLoadFailures(failures);
+
+  if (!components || components.length === 0) return failures;
 
   const activeComponents = components.filter((c) => c.status === "active" && c.bundle_content);
 
@@ -153,7 +158,7 @@ export async function loadCustomComponentsFromMeta(
       `[CustomComponents] ${components.length} component(s) from API but none have active status with bundle_content.`,
       components.map((c) => ({ name: c.name, status: c.status, hasContent: !!c.bundle_content, content: c.bundle_content }))
     );
-    return;
+    return failures;
   }
 
   const componentsToRegister: (typeof Component)[] = [];
@@ -190,6 +195,12 @@ export async function loadCustomComponentsFromMeta(
             `[CustomComponents] "${comp.name}" (key: "${windowKey}") not found on window.__CUSTOM_COMPONENTS__. Available keys:`,
             loadedKeys
           );
+          failures.push({
+            name: comp.name,
+            version: comp.version,
+            customComponentId: comp._id,
+            reason: "Bundle did not register a component. Re-upload it from the latest CLI / Component Studio build.",
+          });
           continue;
         }
       }
@@ -207,6 +218,12 @@ export async function loadCustomComponentsFromMeta(
       componentsToRegister.push(VersionedClass as unknown as typeof Component);
     } catch (err) {
       console.error(`[CustomComponents] Failed to load "${comp.name}" v${comp.version}:`, err);
+      failures.push({
+        name: comp.name,
+        version: comp.version,
+        customComponentId: comp._id,
+        reason: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 
@@ -217,6 +234,9 @@ export async function loadCustomComponentsFromMeta(
       `[CustomComponents] No components registered. ${activeComponents.length} active component(s) loaded but none matched.`
     );
   }
+
+  registry.setCustomLoadFailures(failures);
+  return failures;
 }
 
 export function getCustomComponentsFromPage(pageJson: string): string[] {

--- a/custom-component-loader.ts
+++ b/custom-component-loader.ts
@@ -4,6 +4,7 @@ import ComponentsRegistery, { CustomComponentLoadFailure } from "./editor-compon
 import { CATEGORIES, Component } from "./editor-components/EditorComponent";
 import * as _EditorComponents from "./editor-components/EditorComponent";
 import * as _BaseModule from "./composer-base-components/base/base";
+import { logger } from "classes/Logger";
 
 export interface CustomComponentMeta {
   _id: string;
@@ -101,21 +102,391 @@ function validateCustomComponentContract(BaseClass: unknown, name: string): void
   }
 }
 
-export function scopeToPlayground(css: string): string {
-  return css.replace(
-    /^(\s*)([^@\s\/\n}][^{\n]*?)\s*\{/gm,
-    (_match, indent, selector) => {
-      const trimmed = selector.trim();
-      if (!trimmed || trimmed.startsWith("#playground")) return _match;
-      return `${indent}#playground ${trimmed} {`;
+/**
+ * The single scope every uploaded custom component is confined to. Nothing
+ * an uploaded stylesheet declares may take effect at or above this node.
+ */
+const PLAYGROUND_SCOPE = "#playground";
+
+/**
+ * At-rules whose *body* is itself a list of qualified rules — their nested
+ * selectors must be scoped just like top-level ones. Everything else with a
+ * block (`@keyframes`, `@font-face`) is emitted verbatim: keyframe selectors
+ * (`from`/`to`/`50%`) and font descriptors are NOT selectors and must not be
+ * prefixed.
+ */
+const NESTED_RULE_AT_RULES = new Set([
+  "media",
+  "supports",
+  "layer",
+  "container",
+  "scope",
+  "document",
+  "-moz-document",
+]);
+
+export interface CssScopeViolation {
+  selector: string;
+  reason: string;
+}
+
+/** Advance past a quoted string starting at `start`; returns index after the closing quote. */
+function scanString(input: string, start: number): number {
+  const quote = input[start];
+  let i = start + 1;
+  while (i < input.length) {
+    const ch = input[i];
+    if (ch === "\\") {
+      i += 2;
+      continue;
     }
-  );
+    if (ch === quote) return i + 1;
+    i++;
+  }
+  return input.length;
+}
+
+/** Return the index just past a CSS comment that begins at `start`. */
+function scanComment(input: string, start: number): number {
+  const end = input.indexOf("*/", start + 2);
+  return end === -1 ? input.length : end + 2;
+}
+
+/** Index of the matching closer for an opener (`{`/`(`/`[`) at `openIdx`, comment/string aware. */
+function findMatching(input: string, openIdx: number, open: string, close: string): number {
+  let depth = 0;
+  let i = openIdx;
+  while (i < input.length) {
+    const ch = input[i];
+    if (ch === "/" && input[i + 1] === "*") {
+      i = scanComment(input, i);
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = scanString(input, i);
+      continue;
+    }
+    if (ch === open) depth++;
+    else if (ch === close) {
+      depth--;
+      if (depth === 0) return i;
+    }
+    i++;
+  }
+  return input.length;
+}
+
+/** Split `input` on top-level `delimiter`, ignoring delimiters inside (), [], strings, comments. */
+function splitTopLevel(input: string, delimiter: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = "";
+  let i = 0;
+  while (i < input.length) {
+    const ch = input[i];
+    if (ch === "/" && input[i + 1] === "*") {
+      const stop = scanComment(input, i);
+      current += input.slice(i, stop);
+      i = stop;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      const stop = scanString(input, i);
+      current += input.slice(i, stop);
+      i = stop;
+      continue;
+    }
+    if (ch === "(" || ch === "[") depth++;
+    else if (ch === ")" || ch === "]") depth = Math.max(0, depth - 1);
+    if (ch === delimiter && depth === 0) {
+      parts.push(current);
+      current = "";
+      i++;
+      continue;
+    }
+    current += ch;
+    i++;
+  }
+  parts.push(current);
+  return parts;
+}
+
+/** Remove every pseudo-class / pseudo-element segment (`:x`, `::x`, `:x(...)`) from a compound. */
+function stripPseudos(compound: string): string {
+  let out = "";
+  let i = 0;
+  while (i < compound.length) {
+    if (compound[i] === ":") {
+      i++;
+      if (compound[i] === ":") i++;
+      while (i < compound.length && /[\w-]/.test(compound[i])) i++;
+      if (compound[i] === "(") {
+        i = findMatching(compound, i, "(", ")") + 1;
+      }
+      continue;
+    }
+    out += compound[i];
+    i++;
+  }
+  return out;
+}
+
+/** A compound is "bare universal" when, ignoring pseudo-classes, it is just `*`. */
+function isBareUniversal(compound: string): boolean {
+  return stripPseudos(compound).trim() === "*";
+}
+
+/**
+ * Does a single compound selector target global scope (`:root` / `html` /
+ * `body` / universal `*`)? Unwraps `:is()/:where()/:matches()/:any()` and
+ * tests each inner branch — if any branch targets global, so does the whole.
+ */
+function isGlobalCompound(compound: string): boolean {
+  const c = compound.trim();
+  if (!c) return false;
+
+  const wrap = c.match(/:(?:where|is|matches|any|-moz-any|-webkit-any)\(/i);
+  if (wrap && wrap.index !== undefined) {
+    const parenStart = wrap.index + wrap[0].length - 1;
+    const parenEnd = findMatching(c, parenStart, "(", ")");
+    const inner = c.slice(parenStart + 1, parenEnd);
+    for (const branch of splitTopLevel(inner, ",")) {
+      if (isGlobalSelector(branch)) return true;
+    }
+    const rest = c.slice(0, wrap.index) + c.slice(parenEnd + 1);
+    return rest.trim() ? isGlobalCompound(rest) : false;
+  }
+
+  // The leading type capture is the FULL identifier (`[a-zA-Z][\w-]*`), so an
+  // element-name match can never be a mere prefix of a longer ident: `bodyfoo`
+  // captures as `"bodyfoo"` (no match), only a real `body`/`html` subject hits.
+  const typeMatch = c.match(/^([a-zA-Z][\w-]*)/);
+  const type = typeMatch ? typeMatch[1].toLowerCase() : "";
+  if (type === "html" || type === "body") return true;
+  // Match the real `:root` pseudo-class only — the char after `root` must not
+  // be `[\w-]`, so `:root-thing` (a custom ident) is NOT treated as global.
+  // Mirrors the backend gate's `/:root(?![\w-])/i` so all three surfaces agree.
+  if (/:root(?![\w-])/i.test(c)) return true;
+  if (isBareUniversal(c)) return true;
+  return false;
+}
+
+/** Last compound of a complex selector (its subject), split on top-level combinators. */
+function getSubjectCompound(selector: string): string {
+  let depth = 0;
+  let current = "";
+  let last = "";
+  let i = 0;
+  const flush = () => {
+    if (current.trim()) last = current.trim();
+    current = "";
+  };
+  while (i < selector.length) {
+    const ch = selector[i];
+    if (ch === "/" && selector[i + 1] === "*") {
+      const stop = scanComment(selector, i);
+      current += selector.slice(i, stop);
+      i = stop;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      const stop = scanString(selector, i);
+      current += selector.slice(i, stop);
+      i = stop;
+      continue;
+    }
+    if (ch === "(" || ch === "[") {
+      depth++;
+      current += ch;
+      i++;
+      continue;
+    }
+    if (ch === ")" || ch === "]") {
+      depth = Math.max(0, depth - 1);
+      current += ch;
+      i++;
+      continue;
+    }
+    if (depth === 0 && (ch === ">" || ch === "+" || ch === "~" || /\s/.test(ch))) {
+      flush();
+      i++;
+      continue;
+    }
+    current += ch;
+    i++;
+  }
+  flush();
+  return last;
+}
+
+/** A full selector targets global scope when its subject (last compound) does. */
+function isGlobalSelector(selector: string): boolean {
+  return isGlobalCompound(getSubjectCompound(selector));
+}
+
+/**
+ * Scope one comma-separated selector list to the playground. Each selector is
+ * prefixed individually; selectors that target global scope are dropped and
+ * recorded. Returns the rebuilt list, or "" when every selector was dropped
+ * (signalling the caller to drop the whole rule).
+ */
+function scopeSelectorList(selectorList: string, violations: CssScopeViolation[]): string {
+  const kept: string[] = [];
+  for (const raw of splitTopLevel(selectorList, ",")) {
+    const sel = raw.trim();
+    if (!sel) continue;
+    if (sel.startsWith(PLAYGROUND_SCOPE)) {
+      kept.push(sel);
+      continue;
+    }
+    if (isGlobalSelector(sel)) {
+      violations.push({
+        selector: sel,
+        reason:
+          "targets global scope (:root/html/body/*); its declarations (including --custom-properties) would escape #playground",
+      });
+      continue;
+    }
+    kept.push(`${PLAYGROUND_SCOPE} ${sel}`);
+  }
+  return kept.join(", ");
+}
+
+/** Transform a single `prelude { inner }` rule. Returns "" when the rule is fully dropped. */
+function transformRule(prelude: string, inner: string, violations: CssScopeViolation[]): string {
+  const trimmed = prelude.trim();
+
+  if (trimmed.startsWith("@")) {
+    const atName = (trimmed.match(/^@([\w-]+)/)?.[1] || "").toLowerCase();
+    if (NESTED_RULE_AT_RULES.has(atName)) {
+      // Body is a rule list — recurse so nested selectors get scoped.
+      return `${prelude}{${transformRuleList(inner, violations)}}`;
+    }
+    // @keyframes / @font-face / unknown at-rules with a block: emit verbatim.
+    // Their inner "selectors" are keyframe stops or descriptors, not real
+    // selectors, and they cannot reach outside the canvas on their own.
+    return `${prelude}{${inner}}`;
+  }
+
+  // Qualified rule. The body is emitted verbatim: declarations pass through and
+  // any natively-nested rules are already confined by the scoped parent.
+  const leadingLen = prelude.length - prelude.trimStart().length;
+  const leading = prelude.slice(0, leadingLen);
+  const scoped = scopeSelectorList(trimmed, violations);
+  if (!scoped) return "";
+  return `${leading}${scoped} {${inner}}`;
+}
+
+/**
+ * Walk a rule list (top-level stylesheet or the body of a conditional group
+ * at-rule). Selectors are scoped, global-scope rules dropped, and stray
+ * top-level custom-property declarations (which would otherwise leak to
+ * document scope) are removed.
+ */
+function transformRuleList(css: string, violations: CssScopeViolation[]): string {
+  let out = "";
+  let buffer = "";
+  let i = 0;
+  const len = css.length;
+  while (i < len) {
+    const ch = css[i];
+    if (ch === "/" && css[i + 1] === "*") {
+      const stop = scanComment(css, i);
+      buffer += css.slice(i, stop);
+      i = stop;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      const stop = scanString(css, i);
+      buffer += css.slice(i, stop);
+      i = stop;
+      continue;
+    }
+    if (ch === "{") {
+      const close = findMatching(css, i, "{", "}");
+      const inner = css.slice(i + 1, close);
+      out += transformRule(buffer, inner, violations);
+      buffer = "";
+      i = close + 1;
+      continue;
+    }
+    if (ch === ";") {
+      const stmt = buffer + ";";
+      buffer = "";
+      const t = stmt.trim();
+      if (t.startsWith("--")) {
+        // A custom property declared outside any selector resolves at document
+        // scope — never allow it above the canvas.
+        violations.push({
+          selector: t,
+          reason: "custom property declared outside any selector — would apply above #playground",
+        });
+      } else {
+        // At-rule statements (@import / @charset / @namespace / @layer name;) preserved.
+        out += stmt;
+      }
+      i++;
+      continue;
+    }
+    buffer += ch;
+    i++;
+  }
+  out += buffer;
+  return out;
+}
+
+/** Core pass shared by {@link scopeToPlayground} and {@link findCssScopeViolations}. */
+function processCss(css: string): { css: string; violations: CssScopeViolation[] } {
+  const violations: CssScopeViolation[] = [];
+  const scoped = transformRuleList(css, violations);
+  return { css: scoped, violations };
+}
+
+/**
+ * Detect — without modifying the CSS — every selector that would escape the
+ * playground scope: selectors targeting `:root`/`html`/`body`/`*`, and
+ * custom-property declarations placed above the canvas. Shares its rule set
+ * with {@link scopeToPlayground} so an upload-time gate can reason identically.
+ */
+export function findCssScopeViolations(css: string): CssScopeViolation[] {
+  return processCss(css).violations;
+}
+
+/**
+ * Confine an uploaded component's stylesheet to `#playground`.
+ *
+ * Tokenizer-based (not regex-only) so it is robust against multi-line/comma
+ * selector lists, minified CSS, nested at-rules, comments and strings:
+ *   - Every selector in a comma list is prefixed with `#playground`
+ *     individually, even across newlines.
+ *   - Selectors targeting global scope (`:root`/`html`/`body`/`*`, including
+ *     `:is()/:where()` wrappers and leading combinators) are dropped so an
+ *     uploaded component can never repaint the editor chrome; an emptied rule
+ *     is removed entirely.
+ *   - `@media`/`@supports`/`@layer`/`@container` bodies are recursed into so
+ *     their nested selectors are scoped; `@keyframes`/`@font-face` are left
+ *     intact; other at-rule statements are preserved.
+ */
+export function scopeToPlayground(css: string, componentKey?: string): string {
+  logger.info.function("scopeToPlayground:start", {
+    componentKey,
+    length: css.length,
+  });
+  const { css: scoped, violations } = processCss(css);
+  if (violations.length > 0) {
+    logger.info.state("scopeToPlayground:neutralizedGlobalScope", {
+      componentKey,
+      count: violations.length,
+      violations,
+    });
+  }
+  return scoped;
 }
 
 function injectStylesheet(css: string, key: string): void {
   if (!css.trim()) return;
 
-  const scopedCss = scopeToPlayground(css);
+  const scopedCss = scopeToPlayground(css, key);
   const customStyleLink = document.getElementById("custom-style");
   const existing = document.querySelector(`style[data-key="${key}"]`) as HTMLStyleElement | null;
 

--- a/editor-components/ComponentRegistery.tsx
+++ b/editor-components/ComponentRegistery.tsx
@@ -1,8 +1,23 @@
 import { CATEGORIES, Component, iComponent } from "./EditorComponent";
 
 export type TRegistryState = { [key in CATEGORIES]: typeof Component[] };
+
+/**
+ * A custom component that was fetched but could NOT be registered (bad bundle,
+ * missing addProp, did not extend Component, etc.). Kept OUT of
+ * availableComponents so the page builder never tries to render it; surfaced
+ * separately so the UI can show the user why their component is missing.
+ */
+export type CustomComponentLoadFailure = {
+  name: string;
+  version?: number;
+  reason: string;
+  customComponentId?: string;
+};
+
 class ComponentsRegistery {
   private availableComponents: TRegistryState = {} as TRegistryState;
+  private customLoadFailures: CustomComponentLoadFailure[] = [];
 
   constructor() {
     Object.values(CATEGORIES).forEach((item) => {
@@ -12,6 +27,14 @@ class ComponentsRegistery {
 
   getComponents(): TRegistryState {
     return this.availableComponents;
+  }
+
+  setCustomLoadFailures(failures: CustomComponentLoadFailure[]) {
+    this.customLoadFailures = failures;
+  }
+
+  getCustomLoadFailures(): CustomComponentLoadFailure[] {
+    return this.customLoadFailures;
   }
   register(components: typeof Component[]) {
     components.forEach((component: typeof Component) => {
@@ -78,6 +101,8 @@ class ComponentsRegistery {
       if (typeof window !== "undefined" && window.__CUSTOM_COMPONENTS__) {
         window.__CUSTOM_COMPONENTS__ = {};
       }
+      // Drop recorded load failures too — they are re-derived on next load.
+      this.customLoadFailures = [];
     }
 
     this.availableComponents[category] = [];


### PR DESCRIPTION
## Why
An uploaded custom component set `--bg-base` on the global `:root` and repainted the whole editor tool chrome — a CSS isolation/security bug. The previous `scopeToPlayground` regex only prefixed a selector that sat on the same line as its `{`, so comma-lists / multi-line selectors (e.g. `:root,\n.x {}`) leaked to global scope.

## What
- Rewrote `scopeToPlayground` as a dependency-free, comment/string-aware brace-walking tokenizer.
- Every selector in a list is individually prefixed with `#playground` (comma-lists, multi-line, minified all handled).
- Any selector whose subject compound targets global scope (`:root`, `html`, `body`, bare `*`, incl. `:is()/:where()` wrappers and `@media`/`@supports`/`@layer`-nested) is dropped; stray top-level `--var` declarations are dropped. Each neutralization is logged via `logger.info.state`.
- `@keyframes` / `@font-face` preserved; `body > .card`, `.bodyfoo`, `:root-thing` are NOT over-rejected (uses `/:root(?![\\w-])/`).
- Exported `findCssScopeViolations` so the backend upload gate + component-studio preflight share the same rule set.

This is the authoritative **runtime** layer of a 3-surface defense (backend 422 gate + component-studio preflight in sibling repos). Even already-stored offending components are neutralized on load.

## Verification
- `yarn build` PASS.
- Proven: comma-list `:root` leak neutralized; nested `@media` selectors still scoped; `@keyframes` intact; `.MyComp` → `#playground .MyComp`.

> Note: also carries the pre-existing commit `fe3ab913` (expose load failures for UI surfacing), which was not yet on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)