### PR TITLE
fix(editor-components): guard browser globals during SSR to fix publish prerender crash

### DIFF
--- a/editor-components/Image_gallery/image_gallery_2/image-gallery2.tsx
+++ b/editor-components/Image_gallery/image_gallery_2/image-gallery2.tsx
@@ -801,7 +801,9 @@ class ImageGallery2 extends BaseImageGallery {
 
         this.addProp(INPUTS.BUTTON("button", "Button", "Load More", null, null, null, "Primary"));
 
-        document.addEventListener("keydown", this.handleKeyDown);
+        if (typeof document !== "undefined") {
+            document.addEventListener("keydown", this.handleKeyDown);
+        }
         this.setComponentState("default", 0);
         this.setComponentState("modalOpen", false);
         this.setComponentState("currentImageIndex", 0);

--- a/editor-components/Image_gallery/image_gallery_4/image-gallery4.tsx
+++ b/editor-components/Image_gallery/image_gallery_4/image-gallery4.tsx
@@ -512,7 +512,9 @@ class ImageGallery4 extends BaseImageGallery {
     this.setComponentState("focusedImage", null);
     this.setComponentState("isFocused", false);
     this.setComponentState("moreImages", 0);
-    document.addEventListener("keydown", this.handleKeyDown);
+    if (typeof document !== "undefined") {
+      document.addEventListener("keydown", this.handleKeyDown);
+    }
   }
 
   static getName(): string {

--- a/editor-components/feature/feature9/feature9.tsx
+++ b/editor-components/feature/feature9/feature9.tsx
@@ -267,13 +267,13 @@ class Feature9 extends BaseFeature {
   render() {
     const cards = this.castToObject<Card[]>("cards");
     const buttons = this.castToObject<INPUTS.CastedButton[]>("buttons");
-    const cardElements = document.querySelectorAll("." + this.decorateCSS("card"));
+    const cardElements = typeof document !== "undefined" ? document.querySelectorAll("." + this.decorateCSS("card")) : ([] as unknown as NodeListOf<Element>);
     const title = this.getPropValue("title");
     const subtitle = this.getPropValue("subtitle");
 
     const cardsLengthIsChanged = this.getComponentState("cardLength") != cardElements.length;
 
-    if (cardsLengthIsChanged) {
+    if (cardsLengthIsChanged && typeof document !== "undefined") {
       this.setupObserver();
     }
 

--- a/editor-components/hero-section/hero-section22/hero-section22.tsx
+++ b/editor-components/hero-section/hero-section22/hero-section22.tsx
@@ -310,7 +310,7 @@ class HeroSection22 extends BaseHeroSection {
         }
       },
     };
-    const elements = document.getElementsByClassName(this.decorateCSS("sliders"));
+    const elements = typeof document !== "undefined" ? document.getElementsByClassName(this.decorateCSS("sliders")) : ([] as unknown as HTMLCollectionOf<Element>);
     const items = [];
 
     for (let index = 0; index < elements.length; index++) {

--- a/editor-components/hero-section/hero-section27/hero-section27.tsx
+++ b/editor-components/hero-section/hero-section27/hero-section27.tsx
@@ -466,9 +466,7 @@ class HeroSection27 extends BaseHeroSection {
       },
     };
 
-    const elements = document.getElementsByClassName(
-      this.decorateCSS("carousel")
-    );
+    const elements = typeof document !== "undefined" ? document.getElementsByClassName(this.decorateCSS("carousel")) : ([] as unknown as HTMLCollectionOf<Element>);
 
     const items = [];
 

--- a/editor-components/hero-section/hero-section35/hero-section35.tsx
+++ b/editor-components/hero-section/hero-section35/hero-section35.tsx
@@ -262,6 +262,7 @@ class HeroSection35 extends BaseHeroSection {
         const customerBoxExist = customerBoxImageExist || customerBoxDescriptionExist || customerBoxNumberExist;
         const rightCardExist = rightCard.image || (customerBoxExist && customerBox.visibility);
         const showCustomerBox = customerBoxExist && customerBox.visibility;
+        const htmlBg = (typeof document !== "undefined" ? getComputedStyle(document.documentElement).getPropertyValue('--composer-html-background') : "") || '#fff';
 
         return(
             <Base.Container ref={this.containerRef} className={this.decorateCSS("container")}>
@@ -380,7 +381,7 @@ class HeroSection35 extends BaseHeroSection {
                                                         <path d="M 0 0 L 42 0 C 0 0 40 25 0 20 Z" fill="black" />
                                                     </mask>
                                                 </defs>
-                                                <rect width="25" height="25" fill={getComputedStyle(document.documentElement).getPropertyValue('--composer-html-background') || '#fff'} mask="url(#cutout-topleft)" />
+                                                <rect width="25" height="25" fill={htmlBg} mask="url(#cutout-topleft)" />
                                             </svg>
                                             <svg className={this.decorateCSS("box-corner-right")}>
                                                 <defs>
@@ -389,7 +390,7 @@ class HeroSection35 extends BaseHeroSection {
                                                         <path d="M 0 0 L 42 0 C 0 0 40 25 0 20 Z" fill="black" />
                                                     </mask>
                                                 </defs>
-                                                <rect width="25" height="25" fill={getComputedStyle(document.documentElement).getPropertyValue('--composer-html-background') || '#fff'} mask="url(#cutout-bottomright)" />
+                                                <rect width="25" height="25" fill={htmlBg} mask="url(#cutout-bottomright)" />
                                             </svg>
                                             <div className={this.decorateCSS("customer-box")}> 
                                                 {customerBoxImageExist && <div className={this.decorateCSS("customer-images")}>

--- a/editor-components/hero-section/hero-section4/hero-section4.tsx
+++ b/editor-components/hero-section/hero-section4/hero-section4.tsx
@@ -197,7 +197,7 @@ const getStyle = (direction: "up" | "down") => {
   }
 
   if (direction === "down") {
-    const containerWidth = this.containerRef.current?.offsetWidth || window.innerWidth;
+    const containerWidth = this.containerRef.current?.offsetWidth || (typeof window !== "undefined" ? window.innerWidth : 1024);
     const isMobile = containerWidth <= 640;
     const multiplier = isMobile ? 100: 400;
     const translateY = 100 - multiplier * progress;

--- a/editor-components/hero-section/hero-section9/hero-section9.tsx
+++ b/editor-components/hero-section/hero-section9/hero-section9.tsx
@@ -419,7 +419,7 @@ class HeroSection9 extends BaseHeroSection {
 
     const currentImage = tabs[activeTabIndex]?.image ?? null;
 
-    const socialHeight = window.document.getElementById("header9-social")?.clientHeight
+    const socialHeight = typeof document !== "undefined" ? document.getElementById("header9-social")?.clientHeight : undefined
     const isCounterActive = this.getPropValue("isCounterActive")
     const noTabs = ((tabs.length < 1 || !isCounterActive) && !textExist);
 

--- a/editor-components/logo-clouds/logo-comp10/logo-comp10.tsx
+++ b/editor-components/logo-clouds/logo-comp10/logo-comp10.tsx
@@ -12,6 +12,7 @@ class LogoComp10Page extends LogoClouds {
   containerRef: HTMLDivElement | null = null;
   wheelTimeout: NodeJS.Timeout | null = null;
   resizeObserver: ResizeObserver | null = null;
+  private phoneState: boolean = false;
   constructor(props?: any) {
     super(props, styles);
     this.addProp({
@@ -160,6 +161,7 @@ class LogoComp10Page extends LogoClouds {
     this.handleResize();
   }
   handleResize = () => {
+    this.updatePhoneState();
     this.forceUpdate();
   };
   componentWillUnmount() {
@@ -218,11 +220,13 @@ class LogoComp10Page extends LogoClouds {
   getEffectiveChunkSize = (): number => {
     return this.isPhone() ? Math.min(2, this.getChunkSize()) : this.getChunkSize();
   };
-  isPhone = (): boolean => {
+  isPhone = (): boolean => this.phoneState;
+  private updatePhoneState = (): void => {
+    if (typeof window === "undefined" || typeof document === "undefined") return;
     const width = this.containerRef?.clientWidth
-      ?? document.getElementById('playground')?.clientWidth
+      ?? document.getElementById("playground")?.clientWidth
       ?? window.innerWidth;
-    return width <= 640;
+    this.phoneState = width <= 640;
   };
   chunkLogos = (logos: TImage[], size: number): TImage[][] => {
     const chunkSize = Math.max(1, size);

--- a/editor-components/slider/slider3/slider3.tsx
+++ b/editor-components/slider/slider3/slider3.tsx
@@ -351,7 +351,7 @@ class Slider3 extends BaseSlider {
             <div className={`${this.decorateCSS("slider-parent")} ${hideBottomPadding ? this.decorateCSS("no-bottom-padding") : ""}`}>
               <ComposerSlider {...settings} className={this.decorateCSS("carousel")}>
                 {sliderItems.map((item: SliderItem, index: number) => {
-                  const imageElement = document.getElementById(`slider6Image${index}`);
+                  const imageElement = typeof document !== "undefined" ? document.getElementById(`slider6Image${index}`) : null;
                   const imageHeight = imageElement?.clientHeight || "auto";
                   return (
                     <div


### PR DESCRIPTION
## Problem
Publishing a project failed in `composer-client-image` CI with:
```
ReferenceError: document is not defined
Error occurred prerendering page "/agencies"
```
The published client uses Next.js `output: "export"`, which prerenders every page in **Node**, where `document`/`window`/`getComputedStyle`/`IntersectionObserver` are undefined. Several built-in editor components access those globals **synchronously during `render()` or in the `constructor`**, crashing the whole publish build. The reported failure was **Logo Cloud 10** (`isPhone()` reading `document.getElementById('playground')` from `render()`) on the `/agencies` page.

An audit found **10** components with this bug class (any project using them fails to publish):

| Component | SSR-unsafe access | Path |
|---|---|---|
| logo-comp10 | `document.getElementById` / `window.innerWidth` | render → getEffectiveChunkSize → isPhone |
| hero-section9 | `window.document.getElementById` | render |
| hero-section22 / 27 | `document.getElementsByClassName` | render |
| hero-section35 | `getComputedStyle(document.documentElement)` (×2 SVG rects) | render |
| hero-section4 | `window.innerWidth` | render → getStyle("down") |
| feature9 | `document.querySelectorAll` + `IntersectionObserver` | render → setupObserver |
| slider3 | `document.getElementById` | render (slide map) |
| image-gallery2 / 4 | `document.addEventListener` | constructor |

## Fix
Guard each access with a `typeof` check returning an SSR-safe default. **Browser behavior is unchanged** — the guard is `true` in a browser, so the original expression runs verbatim. logo-comp10 additionally caches phone state in a field and measures post-mount, so SSR and the first client render match (no hydration mismatch).

## Verification
Reproduced the exact failing project (published-record `69807bac…`, the `/agencies` crash) locally with a prod read-only key:
- **Before:** build fails prerendering `/agencies`.
- **After:** `✓ Compiled successfully` · `✓ Generating static pages (29/29)` · 0 "document is not defined" · `/agencies` + `/en/agencies` HTML generated.
- A temporary SSR-audit page server-rendered all 10 fixed components → 98 KB of markup, no crash.
- Re-verified after rebasing onto current `main` (incl. #1238/#1239/#1242).

Editor-components remain runtime-clean (no `logger.*`/`console.*`, no new imports); smallest-possible changes, types preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)