### PR TITLE
fix(css-scope): re-home global custom properties onto #playground

### DIFF
--- a/custom-component-loader.ts
+++ b/custom-component-loader.ts
@@ -325,13 +325,82 @@ function isGlobalSelector(selector: string): boolean {
 }
 
 /**
+ * Extract the *top-level* custom-property declarations (`--name: value`) from a
+ * rule body, discarding every other declaration and any natively-nested rule.
+ *
+ * Tokenizer-based for the same reasons as the rest of this file: values may
+ * contain `;`/`{`/`}` inside strings (`content: ";"`), comments, or balanced
+ * parens (`var(--a, url(x;y))`), so a naive split on `;` corrupts them.
+ */
+function extractCustomProperties(inner: string): string {
+  const out: string[] = [];
+  let buffer = "";
+  let i = 0;
+  const flush = () => {
+    const t = buffer.trim();
+    buffer = "";
+    if (!t.startsWith("--")) return;
+    // A declaration only counts when it actually has a `name: value` split.
+    const colon = t.indexOf(":");
+    if (colon > 0) out.push(t);
+  };
+  while (i < inner.length) {
+    const ch = inner[i];
+    if (ch === "/" && inner[i + 1] === "*") {
+      i = scanComment(inner, i);
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      const stop = scanString(inner, i);
+      buffer += inner.slice(i, stop);
+      i = stop;
+      continue;
+    }
+    if (ch === "(") {
+      const close = findMatching(inner, i, "(", ")");
+      buffer += inner.slice(i, close + 1);
+      i = close + 1;
+      continue;
+    }
+    if (ch === "{") {
+      // A natively-nested rule inside a global block. Its selector is relative
+      // to the global subject, so it is discarded wholesale along with the
+      // buffered prelude — only flat custom properties are re-homed.
+      const close = findMatching(inner, i, "{", "}");
+      buffer = "";
+      i = close + 1;
+      continue;
+    }
+    if (ch === ";") {
+      flush();
+      i++;
+      continue;
+    }
+    buffer += ch;
+    i++;
+  }
+  flush();
+  return out.join(";");
+}
+
+/**
  * Scope one comma-separated selector list to the playground. Each selector is
  * prefixed individually; selectors that target global scope are dropped and
- * recorded. Returns the rebuilt list, or "" when every selector was dropped
- * (signalling the caller to drop the whole rule).
+ * reported back to the caller so their custom properties can be re-homed onto
+ * `#playground`. Returns the rebuilt list (`""` when every selector was
+ * dropped) plus whether any global selector was seen.
  */
-function scopeSelectorList(selectorList: string, violations: CssScopeViolation[]): string {
+function scopeSelectorList(
+  selectorList: string,
+  violations: CssScopeViolation[],
+  inner: string,
+): { scoped: string; hadGlobal: boolean } {
   const kept: string[] = [];
+  let hadGlobal = false;
+  // Only declarations that CANNOT be re-homed justify a violation — custom
+  // properties are preserved (see transformRule), so a token-only global rule
+  // is now fully honoured and must not fail an upload gate.
+  const blocked = stripCustomProperties(inner);
   for (const raw of splitTopLevel(selectorList, ",")) {
     const sel = raw.trim();
     if (!sel) continue;
@@ -340,16 +409,30 @@ function scopeSelectorList(selectorList: string, violations: CssScopeViolation[]
       continue;
     }
     if (isGlobalSelector(sel)) {
-      violations.push({
-        selector: sel,
-        reason:
-          "targets global scope (:root/html/body/*); its declarations (including --custom-properties) would escape #playground",
-      });
+      hadGlobal = true;
+      if (blocked) {
+        violations.push({
+          selector: sel,
+          reason:
+            "targets global scope (:root/html/body/*); its non-custom-property declarations would escape #playground and were dropped",
+        });
+      }
       continue;
     }
     kept.push(`${PLAYGROUND_SCOPE} ${sel}`);
   }
-  return kept.join(", ");
+  return { scoped: kept.join(", "), hadGlobal };
+}
+
+/** True when a rule body carries anything other than flat custom properties. */
+function stripCustomProperties(inner: string): boolean {
+  const withoutProps = inner.replace(/\/\*[\s\S]*?\*\//g, "");
+  const props = extractCustomProperties(inner);
+  // Compare declaration counts rather than text: if every non-empty statement
+  // was a custom property, nothing is lost by dropping the rest.
+  const statements = splitTopLevel(withoutProps, ";").filter(s => s.trim());
+  const propCount = props ? splitTopLevel(props, ";").filter(s => s.trim()).length : 0;
+  return statements.length > propCount;
 }
 
 /** Transform a single `prelude { inner }` rule. Returns "" when the rule is fully dropped. */
@@ -372,9 +455,20 @@ function transformRule(prelude: string, inner: string, violations: CssScopeViola
   // any natively-nested rules are already confined by the scoped parent.
   const leadingLen = prelude.length - prelude.trimStart().length;
   const leading = prelude.slice(0, leadingLen);
-  const scoped = scopeSelectorList(trimmed, violations);
-  if (!scoped) return "";
-  return `${leading}${scoped} {${inner}}`;
+  const { scoped, hadGlobal } = scopeSelectorList(trimmed, violations, inner);
+
+  // A global rule's design tokens are re-homed onto #playground rather than
+  // discarded. Components conventionally declare their palette in
+  // `:root { --bg: … }` and consume it via `var(--bg)`; dropping the block
+  // stripped the definitions while leaving every reference, which silently
+  // rendered the component unstyled (transparent backgrounds). Custom
+  // properties inherit, so #playground reaches every descendant while still
+  // never applying at or above the canvas — the isolation guarantee holds.
+  const rehomed = hadGlobal ? extractCustomProperties(inner) : "";
+  const tokenRule = rehomed ? `${PLAYGROUND_SCOPE}{${rehomed}}` : "";
+
+  if (!scoped) return tokenRule;
+  return `${tokenRule}${leading}${scoped} {${inner}}`;
 }
 
 /**
@@ -443,10 +537,16 @@ function processCss(css: string): { css: string; violations: CssScopeViolation[]
 }
 
 /**
- * Detect — without modifying the CSS — every selector that would escape the
- * playground scope: selectors targeting `:root`/`html`/`body`/`*`, and
- * custom-property declarations placed above the canvas. Shares its rule set
- * with {@link scopeToPlayground} so an upload-time gate can reason identically.
+ * Detect — without modifying the CSS — every declaration that would escape the
+ * playground scope and cannot be salvaged: global selectors carrying
+ * **non-custom-property** declarations, and custom properties declared outside
+ * any selector. Shares its rule set with {@link scopeToPlayground} so an
+ * upload-time gate can reason identically.
+ *
+ * NOTE: a global rule holding *only* custom properties is no longer a
+ * violation — {@link scopeToPlayground} re-homes those onto `#playground`, so
+ * the common `:root { --token: … }` palette block is legal and must not be
+ * rejected at upload time.
  */
 export function findCssScopeViolations(css: string): CssScopeViolation[] {
   return processCss(css).violations;
@@ -462,7 +562,11 @@ export function findCssScopeViolations(css: string): CssScopeViolation[] {
  *   - Selectors targeting global scope (`:root`/`html`/`body`/`*`, including
  *     `:is()/:where()` wrappers and leading combinators) are dropped so an
  *     uploaded component can never repaint the editor chrome; an emptied rule
- *     is removed entirely.
+ *     is removed entirely. Their **custom properties are re-homed onto
+ *     `#playground`** instead of being lost — a component declaring its palette
+ *     in `:root { --bg: … }` keeps working, because custom properties inherit
+ *     down to every descendant while still never applying above the canvas.
+ *     Non-custom declarations on a global selector are still discarded.
  *   - `@media`/`@supports`/`@layer`/`@container` bodies are recursed into so
  *     their nested selectors are scoped; `@keyframes`/`@font-face` are left
  *     intact; other at-rule statements are preserved.


### PR DESCRIPTION
## Problem

Uploaded components conventionally declare their palette in a global block and consume it via `var()`:

```css
:root { --bg-base:#0c100d; --mint:#88e788; --fg:#e8f0ea; }
.hero { background: var(--bg-base); color: var(--fg); }
```

The CSS scoper confines component styles to `#playground` and **drops** any rule targeting global scope (`:root`/`html`/`body`/`*`) so an upload can never repaint the editor chrome. But it dropped the whole block — stripping the **definitions** while keeping every **reference**. Each `var(--token)` then resolved to nothing, so components rendered fully unstyled: transparent backgrounds, no colours.

On `www.blinkpage.app` this hit **14 of 14** home-page components (12–30 tokens each). The only trace was a `logger.info.state("neutralizedGlobalScope")` line; nothing surfaced to the user.

## Change

A global rule's **custom-property declarations are re-homed onto `#playground`** instead of discarded. Custom properties inherit, so every descendant resolves them — while nothing applies at or above the canvas, so **the isolation guarantee is unchanged**.

- `:root { --a:1 }` → `#playground{--a:1}`
- `:root { --a:1; background:red }` → `#playground{--a:1}`; `background` still dropped and reported
- `body{margin:0}`, `*{box-sizing:border-box}` → still dropped (unchanged)
- `--rogue:1;` outside any selector → still rejected (unchanged)
- non-global rules → unchanged

`findCssScopeViolations` no longer reports a global rule holding *only* custom properties, so the upload gate stops rejecting the conventional palette block. Rules that also carry non-custom declarations still report.

## Verification

- 21 unit tests pass, incl. mixed comma lists, values containing `;`/braces inside strings and parens, comments, natively-nested rules, and an assertion that no bare `:root`/`html`/`body` ever reaches the output.
- `real-component-css.test.ts` runs the **live Hero and Nav stylesheets** from www.blinkpage.app (committed as fixtures, so it cannot pass vacuously) and asserts every token they define and use survives scoping.
- Checked against all 14 live home-page component stylesheets: zero tokens lost.
- `yarn build` clean.

## Rollout

The rule is duplicated across three surfaces that must stay in sync — all four PRs should merge together:

| Repo | PR |
| --- | --- |
| composer-tools (shared loader — editor + published client) | this change |
| frontend-composer (submodule bump + tests) | paired |
| composer-client-image (submodule bump) | paired |
| component-studio (upload pre-flight) | paired |
| backend (upload gate, `Component-Service`) | paired |

Existing components need no re-upload; the fix is entirely at render/validate time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
