### PR TITLE
fix(hero-section17): stop content layer occluding slide background images

### DIFF
--- a/editor-components/hero-section/hero-section17/hero-section17.module.scss
+++ b/editor-components/hero-section/hero-section17/hero-section17.module.scss
@@ -41,6 +41,10 @@
         align-items: center;
         justify-content: center;
         z-index: 2;
+        // Base.Container ships an opaque themed background (--composer-html-background).
+        // This layer sits above .bg-img (z-index 0), so it must stay transparent
+        // or it fully occludes the slide background image.
+        background-color: transparent;
         .sub-content {
           max-width: 100%;
           width: 100%;


### PR DESCRIPTION
Fixes Teknodev/frontend-composer#1515

## Symptom
Every slide in **Hero Section 17** has a background image assigned, but adding the section to a page shows no image at all — just the themed background behind the year/description card.

## Root cause
The images were never missing. They were being painted and then covered.

| Layer | Element | Computed |
|---|---|---|
| image | `.bg-img` (`Base.Media` → `<img>`) | `position: absolute; z-index: 0` |
| content | `.sub-container` (`Base.Container`) | `position: relative; z-index: 2`, **opaque** background, full section height |

`Base.Container` carries `:where(.container){ background-color: var(--composer-html-background) }` from `composer-base-components/base/base.module.scss`. Hero Section 17 never overrode it, so the content layer rendered as an opaque full-height panel directly on top of `.bg-img`.

Confirmed in a live browser at `/component-library/hero-section-17`:
- each slide `<img>` is present and fully decoded (`naturalWidth` 1920×700, `opacity: 1`, `visibility: visible`, `object-fit: cover`, box 1200×863);
- `document.elementFromPoint()` over the image returns `.sub-container`, not the `<img>`;
- `.sub-container` computes to `rgb(44, 44, 44)` — fully opaque.

## Fix
One declaration: make `.sub-container` transparent, restoring the intended stacking order `bg-img (0) → overlay (1) → content (2)`.

The base rule is wrapped in `:where()` (zero specificity), so a plain declaration wins the cascade — no `!important`, and **no change to any shared base component**, so there is no blast radius on other sections.

This is the established idiom in this directory: hero-sections **8, 11, 13, 15, 22, 24, 25, 32, 33, 34 and 37** already set `background-color: transparent` on the `Base.Container` that sits over a background image.

## Verification
- Applied the real SCSS change (no dev-tools injection) and reloaded: `.sub-container` computes to `rgba(0, 0, 0, 0)`, hit-testing over the image now returns the content wrapper instead of an opaque panel, and all three slide background images render immediately.
- Title card, `View Content` button and prev/next arrows remain fully legible above the image.
- `npx sass` compiles the module cleanly; emitted CSS contains `… .sub-container { … z-index: 2; background-color: transparent; }`.
- Diff is 1 file, +4 lines (1 declaration + 3 comment lines). No `.tsx` change, no logging added (`editor-components/**` ships runtime-clean).

## Follow-up, not in this PR
`Base.Media` is passed `autoPlay muted loop playsInline` for image-typed slides, which React forwards onto `<img>` and warns about. Harmless to rendering, and shared across 6 hero sections — worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)