### PR TITLE
fix(base): keep Link button padding horizontal-free at every breakpoint

### DIFF
--- a/composer-base-components/base/base.module.scss
+++ b/composer-base-components/base/base.module.scss
@@ -508,13 +508,19 @@
   }
   
     @container (max-width: #{$composer-tablet-width}) {
-        padding: var(--composer-gap-sm) !important;
         font-size: calc(0.9375 * var(--composer-font-size-md)) !important;
+
+        &:not(.link) {
+            padding: var(--composer-gap-sm) !important;
+        }
     }
 
     @container (max-width: #{$composer-phone-width}) {
-        padding: var(--composer-gap-xs) var(--composer-gap-sm) !important;
         font-size: calc(0.875 * var(--composer-font-size-md)) !important;
+
+        &:not(.link) {
+            padding: var(--composer-gap-xs) var(--composer-gap-sm) !important;
+        }
     }
 
   &.primary {


### PR DESCRIPTION
Closes Teknodev/frontend-composer#1517

## Problem

`Base.Button` with `buttonType="Link"` was only horizontal-padding-free on desktop. At tablet and phone widths it silently regained horizontal padding.

Root cause is a specificity/`!important` conflict inside `composer-base-components/base/base.module.scss`:

- `.baseButton.link` declares `padding: var(--composer-gap-xs) 0` — correct, but **no** `!important`.
- The two responsive blocks were declared on the bare `.baseButton` selector **with** `!important` and were not scoped per button type:
  - `@container (max-width: 1024px)` → `padding: var(--composer-gap-sm) !important`
  - `@container (max-width: 640px)` → `padding: var(--composer-gap-xs) var(--composer-gap-sm) !important`

So both shared rules beat the Link variant's own padding below 1024px.

## Fix

Scope only the responsive **padding** declarations to `&:not(.link)`. The responsive `font-size` is deliberately left unscoped so every type — Link included — keeps its existing responsive type scale.

## Measured result

Computed padding read from a real headless-Chrome render (`getComputedStyle`), before vs. after, per type per width — `top/right/bottom/left` in px:

| type | 1400px | 900px (≤1024) | 480px (≤640) |
|---|---|---|---|
| **link — before** | 5/0/5/0 | **10/10/10/10** | **5/10/5/10** |
| **link — after** | 5/0/5/0 | **5/0/5/0** | **5/0/5/0** |
| primary — before/after | 10/20/10/20 | 10/10/10/10 | 5/10/5/10 |
| secondary, tertiary, white, black — before/after | 10/20/10/20 | 10/10/10/10 | 5/10/5/10 |
| bare — before/after | 10/0/10/0 | 10/10/10/10 | 5/10/5/10 |

Link now resolves to `var(--composer-gap-xs) 0` at all three breakpoints. Every other `TypeButton` is byte-identical before vs. after — no 1px drift anywhere.

## Verification

- `sass --no-source-map composer-base-components/base/base.module.scss` → exit 0, compiled cascade inspected directly.
- Compiled `origin/main` and this branch and diffed the CSS output: the entire delta is the two `padding` declarations relocated, values and `!important` preserved.
- Adversarial check on the specificity raise `(0,1,0) → (0,2,0)`: scanned all 275 `!important` padding rules in `editor-components/` for any that target a class actually passed to `<Base.Button>` and could flip a source-order tie. The one candidate (`intro-section8.module.scss:70`) resolves at `(0,5,0)` and wins in both revisions — no flip possible.
- `:not(.link)` is safe under CSS Modules: `.link` is local to this module and hashes into base's scope, so a per-component `decorateCSS("link")` class (e.g. `feature7.tsx:256`) hashes differently and cannot falsely match.
- Zero console errors in the render harness at every width.

## Notes

- `landing-composer` consumes `composer-tools` as a pinned submodule; its `src/composer-tools` gitlink needs bumping **after** this merges.
- Out of scope, pre-existing: `.bare` has the same asymmetry Link just had — `var(--composer-gap-sm) 0` on desktop but padding on all sides below 1024px. Worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)