### PR TITLE
fix(faq6): reposition media overlay text and scale responsive font sizes (#1519)

### DIFF
--- a/editor-components/faq/faq6/faq6.module.scss
+++ b/editor-components/faq/faq6/faq6.module.scss
@@ -156,13 +156,13 @@
                 justify-content: center;
                 align-items: flex-start;
                 z-index: 2;
-                padding-left: var(--composer-gap-xl);
+                padding: calc(var(--composer-gap-lg) * 2);
                 box-sizing: border-box;
                 border-radius: 50%;
 
                 .image-text {
                     color: var(--composer-font-color-secondary) !important;
-                    font-size: 4.5rem;
+                    font-size: 6rem;
                     font-weight: 800;
                     margin: 0;
                     text-align: left;
@@ -180,6 +180,14 @@
                 .image-box {
                     .image {
                         min-height: 300px;
+                    }
+
+                    .image-text-overlay {
+                        padding: var(--composer-gap-lg);
+
+                        .image-text {
+                            font-size: 5rem !important;
+                        }
                     }
                 }
             }
@@ -211,10 +219,10 @@
 
                 .image-box {
                     .image-text-overlay {
-                        padding-left: 20px;
+                        padding: var(--composer-gap-lg);
 
                         .image-text {
-                            font-size: 2.75rem !important;
+                            font-size: 4rem !important;
                         }
                     }
                 }


### PR DESCRIPTION
Closes Teknodev/frontend-composer#1519

## What changed

FAQ 6's circular media overlay text sat flush to the left edge of the media and rendered smaller than the reference design. Per the team's clarifications on the issue, **only the overlay text's padding and responsive font sizes change** — one file, `editor-components/faq/faq6/faq6.module.scss`.

| Breakpoint | `.image-text-overlay` padding | `.image-text` font-size |
|---|---|---|
| Desktop | `calc(var(--composer-gap-lg) * 2)` (was `padding-left: var(--composer-gap-xl)`) | `6rem` (was `4.5rem`) |
| Tablet (<1024px) | `var(--composer-gap-lg)` (new block) | `5rem !important` (new) |
| Mobile (<640px) | `var(--composer-gap-lg)` (was `padding-left: 20px`) | `4rem !important` (was `2.75rem`) |

Tablet and mobile keep `!important` because `base.module.scss`'s `:where(.h1)` rule is itself `!important` below 1024px. Desktop does not need it — `:where()` contributes zero specificity, so the component rule wins on specificity alone. Dropping `!important` from the tablet rule makes it silently render at 44px; this was verified empirically.

The mobile hardcoded `padding-left: 20px` is now a token, incidentally removing a hardcoded px.

## Explicitly not changed

Per clarification 1, untouched and confirmed byte-identical to `main`: media container dimensions, image size, aspect ratio, border radius, accordion height/structure, column layout, and `faq6.tsx`. No new position prop was added (clarification 2).

## Verification

`yarn build` green. Computed values read live from the DOM at each breakpoint (harness root font-size 14px):

| Breakpoint | Observed padding | Observed font-size |
|---|---|---|
| 1440px | 80px all sides | 84px (6rem) |
| 900px | 40px all sides | 70px (5rem) |
| 500px | 40px all sides | 56px (4rem) |

Console clean of anything traceable to faq6. Accordion and circular image render identically to `main` at all three widths.

## Known limitation, not introduced here

Neither `.image-box` nor `.image-text-overlay` has `overflow: hidden`, and there is no line clamp — so a sufficiently long `imageText` spills outside the circle. This is pre-existing on `main`; adding a clip would mean changing the media container, which clarification 1 rules out. The larger desktop font does narrow the margin: roughly 45 characters still fit at 1440px before the text breaks the circle (default value is `"FAQ"`). Raised on the issue for the team to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)