### PR TITLE
fix(editor-component): guard prop value walks against non-array values

### DIFF
--- a/editor-components/EditorComponent.tsx
+++ b/editor-components/EditorComponent.tsx
@@ -345,6 +345,7 @@ export type TypeUsableComponentProps = {
     availableTypes?: MediaType[];
   };
   max?: number;
+  malformed?: boolean;
 } & AvailablePropTypes & {
   getPropValue?: (
     propName: string,
@@ -674,9 +675,14 @@ export abstract class Component
         );
       }
 
+      const isValueArray = Array.isArray(propInState.value);
+      if (isComplexType && !isValueArray) {
+        propInState.malformed = true;
+      }
+
       const isMatchingValue =
         (!isComplexType && propInState.value === value) ||
-        (isComplexType && propInState.value.every((item) => item.getPropValue) && propInState.value === value);
+        (isComplexType && isValueArray && propInState.value.every((item) => item.getPropValue) && propInState.value === value);
 
       if (isMatchingValue) return;
 
@@ -897,9 +903,13 @@ export abstract class Component
   private attachPropId(_prop: TypeUsableComponentProps) {
     _prop.id = generateId(_prop.key);
     if (_prop.type == "array" || _prop.type == "object") {
-      (_prop.value as TypeUsableComponentProps[]).forEach(
-        (v: TypeUsableComponentProps) => this.attachPropId(v)
-      );
+      if (Array.isArray(_prop.value)) {
+        (_prop.value as TypeUsableComponentProps[]).forEach(
+          (v: TypeUsableComponentProps) => this.attachPropId(v)
+        );
+      } else {
+        _prop.malformed = true;
+      }
     }
 
     return _prop;
@@ -924,6 +934,8 @@ export abstract class Component
   }
 
   private syncComplexValue(source: TypeUsableComponentProps[], target: TypeUsableComponentProps[]): void {
+    if (!Array.isArray(source) || !Array.isArray(target)) return;
+
     source.forEach(sourceProp => {
       const targetIndex = target.findIndex(prop => prop.key === sourceProp.key);
       if (targetIndex === -1) return;
@@ -940,6 +952,10 @@ export abstract class Component
       }
 
       if (isComplexType) {
+        if (!Array.isArray(targetProp.value)) {
+          targetProp.malformed = true;
+          return;
+        }
         this.syncComplexValue(
           sourceProp.value as TypeUsableComponentProps[],
           targetProp.value as TypeUsableComponentProps[]
@@ -956,10 +972,16 @@ export abstract class Component
     const prop: TypeUsableComponentProps = this.state.componentProps.props[i];
 
     const isInvalidIndex = i === -1;
+    const isComplexType = prop.type === "array" || prop.type === "object";
+    const isValueMalformed = isComplexType && !Array.isArray(prop.value);
+    if (isValueMalformed) {
+      prop.malformed = true;
+    }
     const isMatchingSimpleValue =
-      prop.type !== "array" && prop.type !== "object" && prop.value === value;
+      !isComplexType && prop.value === value;
     const isMatchingComplexValue =
-      (prop.type === "array" || prop.type === "object") &&
+      isComplexType &&
+      !isValueMalformed &&
       prop.value.every((item) => item.getPropValue) &&
       prop.value === value;
 
@@ -1002,11 +1024,11 @@ export abstract class Component
     let cssClass = [this.styles[section]];
 
     let cssManuplations = Object.entries(this.getCSSClasses()).filter(
-      ([p, v]) => v.length > 0
+      ([p, v]) => Array.isArray(v) && v.length > 0
     );
 
     cssManuplations.forEach(([key, value]: any) => {
-      if (key === section) {
+      if (key === section && Array.isArray(value)) {
         value.forEach((el: any) => {
           cssClass.push(el.class);
         });
@@ -1065,9 +1087,20 @@ export abstract class Component
   }
 
   private castingProcess(object: any) {
+    if (!Array.isArray(object.value)) {
+      if (object.type === "array" || object.type === "object") {
+        object.malformed = true;
+      }
+      return object.type === "object" ? {} : [];
+    }
+
     let casted = object.value.map((propValue: any) => {
       let clonedPropValue = { ...propValue };
       if (clonedPropValue.hasOwnProperty("getPropValue")) {
+        if (!Array.isArray(clonedPropValue.value)) {
+          clonedPropValue.malformed = true;
+          return clonedPropValue;
+        }
         clonedPropValue.value.forEach((nestedObject: any, index: number) => {
           clonedPropValue[nestedObject.key] = clonedPropValue.getPropValue(
             nestedObject.key
@@ -1102,9 +1135,11 @@ export abstract class Component
         let value: any = {};
 
         if (initialProp.type == "object" && isObjectContainsAnotherObject) {
-          initialProp.value.forEach((propVal: any) => {
-            value[propVal.key] = initialProp[propVal.key];
-          });
+          if (Array.isArray(initialProp.value)) {
+            initialProp.value.forEach((propVal: any) => {
+              value[propVal.key] = initialProp[propVal.key];
+            });
+          }
         } else {
           value = manipulatedValue.value;
         }

--- a/editor-components/__tests__/EditorComponent.unit.test.ts
+++ b/editor-components/__tests__/EditorComponent.unit.test.ts
@@ -209,3 +209,371 @@ describe("attachPropId via constructor — array item ID uniqueness", () => {
     expect(JSON.stringify(props)).toContain('"value":null');
   });
 });
+
+function buildTestComponentClass(ComponentClass: any) {
+  return class TestComponent extends ComponentClass {
+    static getName() { return "TestComponent"; }
+    getName() { return "TestComponent"; }
+    getInstanceName() { return "TestComponent"; }
+
+    constructor(props: any) {
+      super(props, { main: {} });
+    }
+
+    render() {
+      return null as any;
+    }
+  };
+}
+
+function buildProductionTriggerProp(): TypeUsableComponentProps {
+  return {
+    type: "array",
+    key: "cards",
+    displayer: "Cards",
+    value: [
+      {
+        type: "object",
+        key: "card",
+        displayer: "Card",
+        value: [
+          { type: "string", key: "title", displayer: "Title", value: "<p>Card Title</p>" },
+          {
+            key: "icon",
+            type: "object",
+            displayer: "Icon",
+            value: { type: "icon", name: "LuRocket" },
+          },
+        ] as TypeUsableComponentProps[],
+      } as TypeUsableComponentProps,
+    ] as TypeUsableComponentProps[],
+  } as TypeUsableComponentProps;
+}
+
+describe("EditorComponent — malformed prop production trigger", () => {
+  it("constructs without throwing when a nested prop declares type object but holds a plain object value", async () => {
+    const { Component } = await import("../EditorComponent");
+    const TestComponent = buildTestComponentClass(Component);
+
+    let instance: any;
+    expect(() => {
+      instance = new (TestComponent as any)({ props: [buildProductionTriggerProp()] });
+    }).not.toThrow();
+
+    const cardsProp = instance.getProps().find((p: any) => p.key === "cards");
+    const cardItem = (cardsProp.value as TypeUsableComponentProps[])[0];
+    const iconProp = (cardItem.value as TypeUsableComponentProps[]).find(
+      (p: any) => p.key === "icon"
+    )!;
+    const titleProp = (cardItem.value as TypeUsableComponentProps[]).find(
+      (p: any) => p.key === "title"
+    )!;
+
+    expect(iconProp.malformed).toBe(true);
+    expect(iconProp.value).toEqual({ type: "icon", name: "LuRocket" });
+    expect(titleProp.id).toBeTruthy();
+    expect(instance.getPropValue("title", { parent_object: cardItem.value })).toBeDefined();
+  });
+});
+
+describe("EditorComponent — malformed array/object values do not throw", () => {
+  const malformedValues: Array<{ label: string; value: any }> = [
+    { label: "string", value: "not-an-array" },
+    { label: "number", value: 42 },
+    { label: "null", value: null },
+    { label: "undefined", value: undefined },
+  ];
+
+  malformedValues.forEach(({ label, value }) => {
+    it(`type object with ${label} value never throws in attachPropId, castToObject, or decorateCSS`, async () => {
+      const { Component } = await import("../EditorComponent");
+      const TestComponent = buildTestComponentClass(Component);
+
+      const malformedProp = {
+        type: "object",
+        key: "broken",
+        displayer: "Broken",
+        value,
+      } as unknown as TypeUsableComponentProps;
+
+      let instance: any;
+      expect(() => {
+        instance = new (TestComponent as any)({ props: [malformedProp] });
+      }).not.toThrow();
+
+      let castedResult: any;
+      expect(() => {
+        castedResult = instance.castToObject("broken");
+      }).not.toThrow();
+      expect(castedResult).toEqual({});
+
+      expect(() => instance.decorateCSS("main")).not.toThrow();
+
+      const brokenProp = instance.getProps().find((p: any) => p.key === "broken");
+      expect(brokenProp.malformed).toBe(true);
+      expect(brokenProp.value).toBe(value);
+    });
+
+    it(`type array with ${label} value never throws in attachPropId, castToObject, or decorateCSS`, async () => {
+      const { Component } = await import("../EditorComponent");
+      const TestComponent = buildTestComponentClass(Component);
+
+      const malformedProp = {
+        type: "array",
+        key: "broken",
+        displayer: "Broken",
+        value,
+      } as unknown as TypeUsableComponentProps;
+
+      let instance: any;
+      expect(() => {
+        instance = new (TestComponent as any)({ props: [malformedProp] });
+      }).not.toThrow();
+
+      let castedResult: any;
+      expect(() => {
+        castedResult = instance.castToObject("broken");
+      }).not.toThrow();
+      expect(castedResult).toEqual([]);
+
+      expect(() => instance.decorateCSS("main")).not.toThrow();
+
+      const brokenProp = instance.getProps().find((p: any) => p.key === "broken");
+      expect(brokenProp.malformed).toBe(true);
+      expect(brokenProp.value).toBe(value);
+    });
+  });
+
+  it("a malformed sibling prop does not break resolution of well-formed siblings", async () => {
+    const { Component } = await import("../EditorComponent");
+    const TestComponent = buildTestComponentClass(Component);
+
+    const malformedProp = {
+      type: "object",
+      key: "broken",
+      displayer: "Broken",
+      value: "not-an-array",
+    } as unknown as TypeUsableComponentProps;
+
+    const wellFormedProp: TypeUsableComponentProps = {
+      type: "string",
+      key: "title",
+      displayer: "Title",
+      value: "<p>Still Works</p>",
+    } as TypeUsableComponentProps;
+
+    let instance: any;
+    expect(() => {
+      instance = new (TestComponent as any)({ props: [malformedProp, wellFormedProp] });
+    }).not.toThrow();
+
+    const titleProp = instance.getProps().find((p: any) => p.key === "title");
+    expect(titleProp.malformed).toBeUndefined();
+    expect(instance.getPropValue("title", { as_string: true })).toBe("<p>Still Works</p>");
+  });
+});
+
+describe("EditorComponent — well-formed props are unaffected by hardening", () => {
+  function buildWellFormedCardsProp(): TypeUsableComponentProps {
+    return {
+      type: "array",
+      key: "cards",
+      displayer: "Cards",
+      value: [
+        {
+          type: "object",
+          key: "card",
+          displayer: "Card",
+          value: [
+            { type: "string", key: "title", displayer: "Title", value: "<p>Alpha</p>" },
+          ] as TypeUsableComponentProps[],
+        } as TypeUsableComponentProps,
+      ] as TypeUsableComponentProps[],
+    } as TypeUsableComponentProps;
+  }
+
+  it("assigns ids to every nested prop and leaves malformed unset", async () => {
+    const { Component } = await import("../EditorComponent");
+    const TestComponent = buildTestComponentClass(Component);
+
+    const instance: any = new (TestComponent as any)({ props: [buildWellFormedCardsProp()] });
+    const cardsProp = instance.getProps().find((p: any) => p.key === "cards");
+    const cardItem = (cardsProp.value as TypeUsableComponentProps[])[0];
+    const titleProp = (cardItem.value as TypeUsableComponentProps[]).find(
+      (p: any) => p.key === "title"
+    )!;
+
+    expect(cardsProp.malformed).toBeUndefined();
+    expect(cardItem.id).toBeTruthy();
+    expect(titleProp.id).toBeTruthy();
+  });
+
+  it("keeps castToObject output unchanged for well-formed props", async () => {
+    const { Component } = await import("../EditorComponent");
+    const TestComponent = buildTestComponentClass(Component);
+
+    const instance: any = new (TestComponent as any)({ props: [buildWellFormedCardsProp()] });
+
+    const castedCards = instance.castToObject("cards") as any[];
+    expect(castedCards).toHaveLength(1);
+    expect(castedCards[0].title).toBeDefined();
+  });
+
+  it("includes a well-formed cssClasses entry's class in decorateCSS output", async () => {
+    const { Component } = await import("../EditorComponent");
+    const TestComponent = buildTestComponentClass(Component);
+
+    const instance: any = new (TestComponent as any)({
+      props: [buildWellFormedCardsProp()],
+      cssClasses: { main: [{ id: "x", class: "custom-cls" }] },
+    });
+
+    const decorated = instance.decorateCSS("main");
+    expect(decorated).toContain("custom-cls");
+  });
+});
+
+describe("EditorComponent — malformed cssClasses entries do not throw in decorateCSS", () => {
+  it("excludes a string cssClasses entry from decorateCSS output", async () => {
+    const { Component } = await import("../EditorComponent");
+    const TestComponent = buildTestComponentClass(Component);
+
+    const instance: any = new (TestComponent as any)({
+      props: [],
+      cssClasses: { main: "a-string" },
+    });
+
+    let decorated = "";
+    expect(() => {
+      decorated = instance.decorateCSS("main");
+    }).not.toThrow();
+    expect(decorated).not.toContain("a-string");
+  });
+
+  it("excludes a null cssClasses entry from decorateCSS output", async () => {
+    const { Component } = await import("../EditorComponent");
+    const TestComponent = buildTestComponentClass(Component);
+
+    const instance: any = new (TestComponent as any)({
+      props: [],
+      cssClasses: { main: null },
+    });
+
+    let decorated = "";
+    expect(() => {
+      decorated = instance.decorateCSS("main");
+    }).not.toThrow();
+    expect(decorated).not.toContain("null");
+  });
+});
+
+describe("EditorComponent — state-mutation guards do not throw on malformed values", () => {
+  it("setProp does not throw when a prop's state value is a plain object instead of an array", async () => {
+    const { Component } = await import("../EditorComponent");
+    const TestComponent = buildTestComponentClass(Component);
+
+    const malformedProp = {
+      type: "array",
+      key: "broken",
+      displayer: "Broken",
+      value: { not: "an-array" },
+    } as unknown as TypeUsableComponentProps;
+
+    const instance: any = new (TestComponent as any)({ props: [malformedProp] });
+
+    expect(() => instance.setProp("broken", [])).not.toThrow();
+
+    const brokenProp = instance.getProps().find((p: any) => p.key === "broken");
+    expect(brokenProp.malformed).toBe(true);
+    expect(brokenProp.value).toEqual([]);
+  });
+
+  it("syncComplexValue does not throw when reached via _syncShadowProps with malformed target values", async () => {
+    const { Component } = await import("../EditorComponent");
+    const TestComponent = buildTestComponentClass(Component);
+
+    const shapeStateProp = {
+      type: "array",
+      key: "shape",
+      displayer: "Shape",
+      value: "not-an-array",
+    } as unknown as TypeUsableComponentProps;
+
+    const cardsStateProp: TypeUsableComponentProps = {
+      type: "array",
+      key: "cards",
+      displayer: "Cards",
+      value: [
+        {
+          type: "object",
+          key: "card",
+          displayer: "Card",
+          value: [
+            { type: "string", key: "title", displayer: "Title", value: "orig" },
+          ] as TypeUsableComponentProps[],
+        } as TypeUsableComponentProps,
+      ] as TypeUsableComponentProps[],
+    } as TypeUsableComponentProps;
+
+    const instance: any = new (TestComponent as any)({
+      props: [shapeStateProp, cardsStateProp],
+    });
+
+    instance.addProp({
+      type: "array",
+      key: "shape",
+      displayer: "Shape",
+      value: [{ type: "string", key: "title", displayer: "Title", value: "x" }],
+    });
+    instance.addProp({
+      type: "array",
+      key: "cards",
+      displayer: "Cards",
+      value: [
+        {
+          type: "object",
+          key: "card",
+          displayer: "Card",
+          value: [{ type: "string", key: "title", displayer: "Title", value: "x" }],
+        },
+      ],
+    });
+
+    const cardsProp = instance.getProp("cards");
+    const cardItem = (cardsProp.value as TypeUsableComponentProps[])[0];
+    cardItem.value = "not-an-array";
+    cardItem.malformed = undefined;
+
+    expect(() => instance._syncShadowProps()).not.toThrow();
+
+    expect(cardItem.malformed).toBe(true);
+  });
+
+  it("_syncShadowProps marks a prop malformed without throwing when its complex value collapses to a non-array", async () => {
+    const { Component } = await import("../EditorComponent");
+    const TestComponent = buildTestComponentClass(Component);
+
+    const brokenStateProp: TypeUsableComponentProps = {
+      type: "array",
+      key: "broken",
+      displayer: "Broken",
+      value: [],
+    } as TypeUsableComponentProps;
+
+    const instance: any = new (TestComponent as any)({ props: [brokenStateProp] });
+
+    instance.addProp({
+      type: "array",
+      key: "broken",
+      displayer: "Broken",
+      value: [{ type: "string", key: "title", displayer: "Title", value: "x" }],
+    });
+
+    const brokenProp = instance.getProp("broken");
+    brokenProp.value = "not-an-array";
+    brokenProp.malformed = undefined;
+
+    expect(() => instance._syncShadowProps()).not.toThrow();
+    expect(instance.getProp("broken").malformed).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes Teknodev/frontend-composer#1533

## Problem

`EditorComponent` trusted the prop `type` tag. A stored prop that declared `type: "array"` or `type: "object"` but held a plain object made `.forEach` throw inside the constructor. React could not mount the component, so `MemorizedSection` rendered "Section failed to render" and every other prop of that section was lost.

Production project `696e3554c54ed666c927ced7`, page `/editor/2`: `TypeError: e.value.forEach is not a function`. 5 sections dead on one page, 26 across the project. The trigger is a stored prop `{ key: "icon", type: "object", value: { type: "icon", name: "LuRocket" } }`.

## Change

Seven call sites now check `Array.isArray` before they walk `prop.value`. `attachValueGetter` already used this pattern and is the reference.

| Method | Guard |
|---|---|
| `attachPropId` | skips the recursion |
| `decorateCSS` | filters non-array `cssClasses` entries; the old filter was `v.length > 0`, which a string also passes |
| `castingProcess` | returns an empty result instead of throwing |
| `setProp` | skips the `.every` check |
| `syncComplexValue` | skips the recursion on both source and target |
| `_syncShadowProps` | skips the `.every` check |

A prop that fails the check gets `malformed = true`. `TypeUsableComponentProps` carries a new optional `malformed?: boolean` field.

**The original `value` is never overwritten.** Repairing the stored data is a separate task, and that task must still read the original value.

`castingProcess` sets the flag only when `type` is `"array"` or `"object"`, so a well-formed simple prop is never marked.

## Behaviour for well-formed props

Unchanged. `attachPropId` still assigns an id to every nested prop, `castToObject` returns the same result, and `decorateCSS` returns the same class string.

## Proof

- `npx vitest run src/composer-tools/editor-components/__tests__/EditorComponent.unit.test.ts` — 23 of 23 pass. 5 tests existed before, 18 are new, none were deleted.
- Mutation check: every new test was re-run with its own guard removed. Each one fails without its guard, so no test is vacuous.
- `yarn build` passes. `tsc --noEmit` reports the same 2165 pre-existing errors, none new.
- Full unit suite: no regression. The 41 failures are pre-existing localization and theme tests this change never touches.
- Chrome: the editor boots from this branch, Hero Section 1 and Feature 1 render, and no console error mentions `EditorComponent`, `forEach is not a function`, or `Section failed to render`.
- `grep -rn "console\.\|logger\." editor-components` returns 0. The folder stays runtime-clean.

## Out of scope

- Repairing the stored data.
- Finding the writer that produces the malformed prop.
- Rendering the `malformed` flag in the editor UI.
- `setProp` reads `prop.type` before it checks `isInvalidIndex`, so an unknown key still throws. This is a pre-existing defect of a different class.

## Ships with

`Teknodev/frontend-composer` needs the submodule pointer bump. Merge that pull request after this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)