### PR TITLE
feat(loader): expose ComposerLink on the ComposerTools global

### DIFF
--- a/custom-component-loader.ts
+++ b/custom-component-loader.ts
@@ -4,6 +4,10 @@ import ComponentsRegistery, { CustomComponentLoadFailure } from "./editor-compon
 import { CATEGORIES, Component } from "./editor-components/EditorComponent";
 import * as _EditorComponents from "./editor-components/EditorComponent";
 import * as _BaseModule from "./composer-base-components/base/base";
+import ComposerLink, {
+  setComposerLink,
+  getComposerLink,
+} from "./composer-base-components/Link/ComposerLinkProvider";
 import { logger } from "classes/Logger";
 
 export interface CustomComponentMeta {
@@ -34,7 +38,19 @@ if (typeof window !== "undefined") {
   }
   window.React = React;
   window.ReactDOM = ReactDOM;
-  window.ComposerTools = { ..._EditorComponents, ..._BaseModule };
+  // Custom-component bundles resolve `@blinkpage/composer-tools` to this global
+  // (component-studio externalises the package), so anything they import must be
+  // spread here. ComposerLink is listed explicitly because it is a default
+  // export — spreading its module would land it under `default`, not the name
+  // the bundles actually look up. Without it every custom component that links
+  // somewhere renders `undefined` and React throws #130.
+  window.ComposerTools = {
+    ..._EditorComponents,
+    ..._BaseModule,
+    ComposerLink,
+    setComposerLink,
+    getComposerLink,
+  };
 }
 
 function execScript(code: string, label: string): void {


### PR DESCRIPTION
Custom-component bundles resolve `@blinkpage/composer-tools` to the `ComposerTools` global (component-studio externalises the package), but the global was built from EditorComponent + base only. Neither exports the link provider, so `import { ComposerLink }` resolved to `undefined` in both the editor and the published client, and any custom component that linked somewhere threw React #130.

ComposerLink is listed explicitly rather than spread: it is a default export, so spreading its module would land it under `default`, not the name the bundles look up.

Because the provider resolves `getComposerLink()` at render time, custom components now get the exact implementation the host injected — page-change in the editor, next/link in the published site — matching built-in components.