### PR TITLE
fix(LottiePlayer): render .lottie (dotLottie) via @dotlottie/player-component

### DIFF
--- a/composer-base-components/base/utitilities/LottiePlayer.tsx
+++ b/composer-base-components/base/utitilities/LottiePlayer.tsx
@@ -1,17 +1,27 @@
 import * as React from "react";
 
 /**
- * Loads the `<lottie-player>` web component once, on demand.
+ * Loads the `<dotlottie-player>` web component once, on demand.
  *
  * The custom element is not bundled — it is injected from a CDN the first time a
  * Lottie is rendered, mirroring how the app already loads other third-party
- * players/SDKs. Custom elements upgrade retroactively, so any `<lottie-player>`
+ * players/SDKs. Custom elements upgrade retroactively, so any `<dotlottie-player>`
  * already in the DOM starts animating as soon as the script defines the element.
+ *
+ * We use `@dotlottie/player-component` instead of `@lottiefiles/lottie-player`
+ * because the latter only renders plain Lottie JSON — it cannot decode the
+ * `.lottie` (dotLottie, a ZIP-packaged) format, which left `.lottie` sources
+ * blank. `<dotlottie-player>` renders BOTH plain `.json` and `.lottie`.
+ *
+ * The pinned `dist/dotlottie-player.js` is a UMD bundle (IIFE/UMD wrapper that
+ * self-registers the custom element), so it loads correctly via the classic
+ * `<script src async>` loader below — do NOT switch to the `.mjs` ESM build,
+ * which would require `type="module"`.
  *
  * Pinned to a specific version so a CDN "latest" bump can't change behavior.
  */
 const LOTTIE_PLAYER_SRC =
-  "https://unpkg.com/@lottiefiles/lottie-player@2.0.12/dist/lottie-player.js";
+  "https://unpkg.com/@dotlottie/player-component@2.7.12/dist/dotlottie-player.js";
 
 let lottiePlayerPromise: Promise<void> | null = null;
 
@@ -19,7 +29,7 @@ export function ensureLottiePlayer(): Promise<void> {
   if (typeof window === "undefined") return Promise.resolve();
 
   // Already defined (script loaded, or bundled elsewhere) — nothing to do.
-  if (window.customElements?.get("lottie-player")) return Promise.resolve();
+  if (window.customElements?.get("dotlottie-player")) return Promise.resolve();
 
   if (lottiePlayerPromise) return lottiePlayerPromise;
 
@@ -63,9 +73,9 @@ export interface LottiePlayerProps {
 }
 
 /**
- * Thin React wrapper around the `<lottie-player>` custom element that guarantees
- * the defining script is loaded. Use this instead of a raw `<lottie-player>` so
- * the element is never left un-upgraded.
+ * Thin React wrapper around the `<dotlottie-player>` custom element that
+ * guarantees the defining script is loaded. Use this instead of a raw
+ * `<dotlottie-player>` so the element is never left un-upgraded.
  */
 const LottiePlayer: React.FC<LottiePlayerProps> = ({
   src,
@@ -77,7 +87,7 @@ const LottiePlayer: React.FC<LottiePlayerProps> = ({
   ...rest
 }) => {
   const [ready, setReady] = React.useState<boolean>(
-    () => typeof window !== "undefined" && !!window.customElements?.get("lottie-player")
+    () => typeof window !== "undefined" && !!window.customElements?.get("dotlottie-player")
   );
 
   React.useEffect(() => {
@@ -95,7 +105,7 @@ const LottiePlayer: React.FC<LottiePlayerProps> = ({
 
   // Re-key on src+settings so switching the source or toggling loop/autoplay
   // re-instantiates the player instead of reusing a stale animation.
-  return React.createElement("lottie-player", {
+  return React.createElement("dotlottie-player", {
     key: `${src}-${!!loop}-${!!autoplay}`,
     className,
     src,


### PR DESCRIPTION


<lottie-player> (@lottiefiles/lottie-player) only renders plain Lottie JSON and leaves the packaged .lottie (a zip) blank. Switch to @dotlottie/player-component (<dotlottie-player>), whose pinned dist/dotlottie-player.js is a UMD bundle that self-registers the custom element (works with the existing async <script> loader, no type=module needed) and renders BOTH plain .json and .lottie. Props unchanged.